### PR TITLE
fix: set dock band icon and remove non-location dock band

### DIFF
--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Timer = System.Timers.Timer;
 
@@ -17,6 +18,8 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 	private readonly WeatherBandCard _contentPage;
 	private readonly Timer _updateTimer;
 	private bool _isDisposed;
+
+	internal ICommandItem? DockItem { get; set; }
 
 	public CurrentWeatherBand(
 		OpenMeteoService weatherService,
@@ -78,6 +81,11 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 				var condition = Icons.GetWeatherDescription(weather.Current.WeatherCode);
 				Title = $"{weather.Current.Temperature:F0}{unit} {condition}";
 				Icon = Icons.GetIconForWeatherCode(weather.Current.WeatherCode);
+
+				if (DockItem is CommandItem dockCommandItem)
+				{
+					dockCommandItem.Icon = Icon;
+				}
 
 				// Fetch today's forecast for high/low
 				var forecast = await _weatherService.GetForecastAsync(

--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -5,6 +5,7 @@
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Timer = System.Timers.Timer;
 
@@ -18,6 +19,8 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 	private readonly WeatherBandCard _contentPage;
 	private readonly Timer _updateTimer;
 	private bool _isDisposed;
+
+	internal ICommandItem? DockItem { get; set; }
 
 	public PinnedWeatherBand(
 		GeocodingResult location,
@@ -66,6 +69,11 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 				var condition = Icons.GetWeatherDescription(weather.Current.WeatherCode);
 				Title = $"{weather.Current.Temperature:F0}{unit} {condition}";
 				Icon = Icons.GetIconForWeatherCode(weather.Current.WeatherCode);
+
+				if (DockItem is CommandItem dockCommandItem)
+				{
+					dockCommandItem.Icon = Icon;
+				}
 
 				var forecast = await _weatherService.GetForecastAsync(
 					_location.Latitude,

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -59,9 +59,12 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 			"com.baldbeardedbuilder.cmdpal.weather.dockBand",
 			"Weather");
 
+		wrappedBand.Icon = Icons.WeatherIcon;
+		_currentWeatherBand.DockItem = wrappedBand;
+
 		dockItems.Add(wrappedBand);
 
-		var pinnedLocations = _pinnedLocationsManager.GetPinnedLocations();
+		var pinnedLocations= _pinnedLocationsManager.GetPinnedLocations();
 		foreach (var pinnedLocation in pinnedLocations)
 		{
 			var location = pinnedLocation.ToGeocodingResult();
@@ -73,6 +76,9 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 				[pinnedBand],
 				$"com.baldbeardedbuilder.cmdpal.weather.pinnedBand.{pinnedLocation.Latitude}_{pinnedLocation.Longitude}",
 				$"Weather - {pinnedLocation.DisplayName}");
+
+			pinnedWrappedBand.Icon = Icons.WeatherIcon;
+			pinnedBand.DockItem = pinnedWrappedBand;
 
 			dockItems.Add(pinnedWrappedBand);
 		}


### PR DESCRIPTION
Remove the main weather dock band (CurrentWeatherBand) so only pinned locations appear in the dock. Set dynamic weather-condition icons on pinned dock bands by syncing PinnedWeatherBand's icon to its parent WrappedDockItem on each weather update.

Fixes #13