### PR TITLE
Add automated release workflow for Microsoft Store submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release to Microsoft Store
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: Extract and format version from release tag
+        id: version
+        shell: pwsh
+        run: |
+          $tag = "${{ github.event.release.tag_name }}"
+          $version = $tag -replace '^v', ''
+          
+          # Ensure 4-part version (X.Y.Z.0)
+          $parts = $version -split '\.'
+          if ($parts.Length -eq 3) {
+            $version = "$version.0"
+          }
+          
+          Write-Host "Version: $version"
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+      
+      - name: Update Package.appxmanifest version
+        shell: pwsh
+        run: |
+          $manifestPath = "WeatherExtension/Package.appxmanifest"
+          $version = "${{ steps.version.outputs.version }}"
+          
+          [xml]$manifest = Get-Content $manifestPath
+          $manifest.Package.Identity.Version = $version
+          $manifest.Save($manifestPath)
+          
+          Write-Host "Updated Package.appxmanifest to version $version"
+      
+      - name: Restore dependencies
+        run: dotnet restore WeatherExtension.slnx
+      
+      - name: Build x64
+        run: dotnet build WeatherExtension/WeatherExtension.csproj -c Release -r win-x64 --no-restore
+      
+      - name: Build ARM64
+        run: dotnet build WeatherExtension/WeatherExtension.csproj -c Release -r win-arm64 --no-restore
+      
+      - name: Run tests
+        run: dotnet test WeatherExtension.Tests/ -c Release -r win-x64 --no-build
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            WeatherExtension/bin/
+            WeatherExtension/obj/
+            WeatherExtension.Tests/bin/
+            WeatherExtension.Tests/obj/
+            WeatherExtension/Package.appxmanifest
+          retention-days: 1
+
+  package:
+    needs: build-and-test
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+      
+      - name: Restore dependencies
+        run: dotnet restore WeatherExtension.slnx
+      
+      - name: Publish x64 MSIX
+        run: dotnet publish WeatherExtension/WeatherExtension.csproj -c Release -r win-x64 /p:PublishProfile=win-x64
+      
+      - name: Publish ARM64 MSIX
+        run: dotnet publish WeatherExtension/WeatherExtension.csproj -c Release -r win-arm64 /p:PublishProfile=win-arm64
+      
+      - name: Find and upload MSIX packages
+        shell: pwsh
+        run: |
+          $msixFiles = Get-ChildItem -Path "WeatherExtension/AppPackages" -Filter "*.msix" -Recurse
+          
+          foreach ($file in $msixFiles) {
+            Write-Host "Found MSIX: $($file.FullName)"
+          }
+          
+          if ($msixFiles.Count -eq 0) {
+            Write-Error "No MSIX packages found!"
+            exit 1
+          }
+      
+      - name: Upload MSIX artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: msix-packages
+          path: WeatherExtension/AppPackages/**/*.msix
+          retention-days: 7
+
+  store-submit:
+    needs: package
+    runs-on: windows-latest
+    
+    steps:
+      - name: Download MSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: msix-packages
+          path: msix-packages
+      
+      - name: Setup Microsoft Store CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.2
+      
+      - name: Configure Store credentials
+        shell: pwsh
+        run: |
+          msstore reconfigure `
+            --tenantId "${{ secrets.PARTNER_CENTER_TENANT_ID }}" `
+            --sellerId "${{ secrets.PARTNER_CENTER_SELLER_ID }}" `
+            --clientId "${{ secrets.PARTNER_CENTER_CLIENT_ID }}" `
+            --clientSecret "${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}"
+      
+      - name: Submit to Microsoft Store
+        shell: pwsh
+        run: |
+          msstore publish msix-packages --id "${{ secrets.STORE_PRODUCT_ID }}"
+      
+      - name: Upload MSIX packages to GitHub Release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $msixFiles = Get-ChildItem -Path "msix-packages" -Filter "*.msix" -Recurse
+          
+          foreach ($file in $msixFiles) {
+            Write-Host "Uploading $($file.Name) to release..."
+            gh release upload "${{ github.event.release.tag_name }}" "$($file.FullName)" --clobber
+          }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,68 @@
+# Releasing Weather for Command Palette
+
+## Overview
+
+This project uses an automated release pipeline via GitHub Actions. Creating a GitHub Release triggers a workflow that builds the extension, runs tests, creates MSIX packages, and submits to the Microsoft Store.
+
+## Prerequisites (One-Time Setup)
+
+### 1. Microsoft Entra ID App Registration
+
+1. Go to [Azure Portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps)
+2. Click **New registration**
+3. Name it (e.g., "WeatherExtension CI")
+4. Note the **Application (client) ID** and **Directory (tenant) ID**
+5. Go to **Certificates & secrets** → **New client secret** → note the **Value**
+6. In [Partner Center](https://partner.microsoft.com/dashboard) → **Account Settings** → **User Management**
+7. Add the application with **Manager** role
+
+### 2. Partner Center IDs
+
+1. **Seller ID:** Partner Center → **Account Settings** → **Organization profile** → **Identifiers**
+2. **Product ID:** Partner Center → **Apps and Games** → select "Weather for Command Palette" → note the App ID from the URL
+
+### 3. GitHub Repository Secrets
+
+Go to the repo **Settings** → **Secrets and variables** → **Actions** → **New repository secret**. Add:
+
+| Secret Name | Source |
+|---|---|
+| `PARTNER_CENTER_TENANT_ID` | Entra ID → Directory (tenant) ID |
+| `PARTNER_CENTER_CLIENT_ID` | Entra ID → Application (client) ID |
+| `PARTNER_CENTER_CLIENT_SECRET` | Entra ID → Client secret value |
+| `PARTNER_CENTER_SELLER_ID` | Partner Center → Seller ID |
+| `STORE_PRODUCT_ID` | Partner Center → Product/App ID |
+
+## How to Release
+
+1. Ensure all changes are merged to `main`
+2. Go to GitHub → **Releases** → **Create a new release**
+3. Create a new tag using semantic versioning: `v1.0.1`, `v1.2.0`, etc.
+4. Write release notes (or use auto-generated notes)
+5. Click **Publish release**
+
+The workflow automatically:
+- Builds x64 and ARM64 architectures
+- Runs all tests
+- Creates MSIX packages
+- Submits to the Microsoft Store
+- Uploads MSIX packages to the release as downloadable artifacts
+
+## Tag Naming Convention
+
+- Format: `vMAJOR.MINOR.PATCH` (e.g., `v1.0.1`)
+- The `v` prefix is stripped and `.0` is appended to create the 4-part version for the MSIX manifest (e.g., `1.0.1.0`)
+
+## What Happens After Publishing
+
+- The Microsoft Store reviews the submission (may take 1–3 business days)
+- If approved, the update is available to users via the Store
+- The MSIX packages attached to the GitHub Release can be used for sideloading
+
+## Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| Workflow fails at "Configure Store credentials" | Verify all 5 GitHub secrets are set correctly |
+| Store submission rejected | Check Partner Center dashboard for validation errors |
+| Build fails | The release workflow uses the same build process as CI — check for build errors in the Actions log |


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automates the full release lifecycle when a GitHub Release is published.

## What it does

1. **Build & test** — builds the extension for both x64 and ARM64, runs all tests
2. **Package** — stamps the version from the release tag into `Package.appxmanifest`, creates MSIX packages
3. **Store submit** — submits packages to the Microsoft Store via `msstore` CLI, uploads MSIX files to the GitHub Release as downloadable artifacts

## Files added

| File | Purpose |
|------|---------|
| `.github/workflows/release.yml` | 3-job release workflow triggered on `release: [published]` |
| `RELEASING.md` | Documents prerequisite setup and release process |

## Prerequisites (one-time setup before first use)

The workflow requires 5 GitHub repository secrets for Microsoft Store API access:

- `PARTNER_CENTER_TENANT_ID`
- `PARTNER_CENTER_CLIENT_ID`
- `PARTNER_CENTER_CLIENT_SECRET`
- `PARTNER_CENTER_SELLER_ID`
- `STORE_PRODUCT_ID`

Full setup instructions in `RELEASING.md`.

## How to release

1. Merge to `main`
2. Create a GitHub Release with a tag like `v1.0.1`
3. The workflow handles the rest automatically