### PR TITLE
fix: flatten Store MSIX artifact and fix version in store-submit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,26 +256,58 @@ jobs:
           /p:AppxPackageSigningEnabled=false
           /p:Version=${{ needs.build-and-test.outputs.version }}
 
+      - name: Collect Store MSIX packages
+        shell: pwsh
+        run: |
+          New-Item -Path "store-packages" -ItemType Directory -Force
+          $msixFiles = Get-ChildItem -Path "WeatherExtension" -Filter "*.msix" -Recurse
+          foreach ($file in $msixFiles) {
+            Write-Host "Copying $($file.Name) to store-packages/"
+            Copy-Item $file.FullName -Destination "store-packages/$($file.Name)"
+          }
+
       - name: Upload Store MSIX artifacts
         uses: actions/upload-artifact@v7
         with:
           name: msix-store-packages
-          path: WeatherExtension/**/*.msix
+          path: store-packages/*.msix
           retention-days: 7
 
   store-submit:
-    needs: package
+    needs: [package, build-and-test]
     runs-on: windows-latest
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Update Package.appxmanifest for Store
+        shell: pwsh
+        run: |
+          $manifestPath = "WeatherExtension/Package.appxmanifest"
+          $version = "${{ needs.build-and-test.outputs.version }}"
+          $storePublisher = "${{ secrets.STORE_PUBLISHER_NAME }}"
+
+          [xml]$manifest = Get-Content $manifestPath
+          $manifest.Package.Identity.Version = $version
+          $manifest.Package.Identity.Publisher = $storePublisher
+          $manifest.Save($manifestPath)
+
+          Write-Host "Updated manifest: Version=$version, Publisher=$storePublisher"
+
       - name: Download MSIX artifacts
         uses: actions/download-artifact@v8
         with:
           name: msix-store-packages
           path: msix-packages
+
+      - name: List Store MSIX packages
+        shell: pwsh
+        run: |
+          Write-Host "Store MSIX packages to submit:"
+          Get-ChildItem -Path "msix-packages" -Filter "*.msix" -Recurse | ForEach-Object {
+            Write-Host "  $($_.FullName) ($([math]::Round($_.Length / 1MB, 2)) MB)"
+          }
       
       - name: Setup Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.3


### PR DESCRIPTION
## Problem

The store-submit job submits packages with the wrong version to the Microsoft Store due to three compounding issues:

1. Nested artifact - MSIX files are deeply nested and the msstore CLI -i flag cannot find them
2. Stale manifest - Fresh checkout has Version 1.0.0.0 and sideload publisher
3. No version access - store-submit only depended on package, not build-and-test

## Solution

1. Flatten artifact - Copy .msix files to a flat store-packages directory before uploading
2. Add build-and-test dependency - store-submit now gets version access
3. Update manifest - Set correct version and Store publisher in checkout before msstore publish
4. Debug logging - List Store MSIX packages before submission
