### PR TITLE
Unifying logging into WeatherLogger

### DIFF
--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -2,7 +2,7 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Net.Http;
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
@@ -123,10 +123,9 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		}
 		catch (HttpRequestException ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Band weather network error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Band weather network error: {ex.Message}");
 
 			if (Title == Resources.loading)
 			{
@@ -136,10 +135,9 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Band weather update error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Band weather update error: {ex.Message}");
 
 			if (Title == Resources.loading)
 			{

--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -124,7 +124,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		catch (HttpRequestException ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Band weather network error: {ex.Message}");
 
 			if (Title == Resources.loading)
@@ -136,7 +136,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Band weather update error: {ex.Message}");
 
 			if (Title == Resources.loading)

--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -110,7 +110,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		catch (HttpRequestException ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Pinned band weather network error: {ex.Message}");
 
 			if (Title == Resources.loading)
@@ -122,7 +122,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Pinned band weather update error: {ex.Message}");
 
 			if (Title == Resources.loading)

--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -2,7 +2,7 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Net.Http;
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
@@ -109,10 +109,9 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		}
 		catch (HttpRequestException ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Pinned band weather network error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Pinned band weather network error: {ex.Message}");
 
 			if (Title == Resources.loading)
 			{
@@ -122,10 +121,9 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Pinned band weather update error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Pinned band weather update error: {ex.Message}");
 
 			if (Title == Resources.loading)
 			{

--- a/WeatherExtension/Pages/HourlyForecastPage.cs
+++ b/WeatherExtension/Pages/HourlyForecastPage.cs
@@ -73,7 +73,7 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load hourly forecast: {ex.Message}");
 
 			lock (_sync)

--- a/WeatherExtension/Pages/HourlyForecastPage.cs
+++ b/WeatherExtension/Pages/HourlyForecastPage.cs
@@ -2,6 +2,7 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
@@ -71,10 +72,9 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Failed to load hourly forecast: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to load hourly forecast: {ex.Message}");
 
 			lock (_sync)
 			{

--- a/WeatherExtension/Pages/WeatherBandCard.cs
+++ b/WeatherExtension/Pages/WeatherBandCard.cs
@@ -97,7 +97,7 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Content page weather load error: {ex.Message}");
 
 			_weatherForm.DataJson = GetErrorData(

--- a/WeatherExtension/Pages/WeatherBandCard.cs
+++ b/WeatherExtension/Pages/WeatherBandCard.cs
@@ -2,12 +2,12 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using System.Globalization;
-using System.Threading;
 
 namespace Microsoft.CmdPal.Ext.Weather.Pages;
 
@@ -96,10 +96,9 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Content page weather load error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Content page weather load error: {ex.Message}");
 
 			_weatherForm.DataJson = GetErrorData(
 				Resources.unavailable);

--- a/WeatherExtension/Pages/WeatherDetailPage.cs
+++ b/WeatherExtension/Pages/WeatherDetailPage.cs
@@ -87,7 +87,7 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load weather detail: {ex.Message}");
 
 			lock (_sync)

--- a/WeatherExtension/Pages/WeatherDetailPage.cs
+++ b/WeatherExtension/Pages/WeatherDetailPage.cs
@@ -2,6 +2,7 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
@@ -85,10 +86,9 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Failed to load weather detail: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to load weather detail: {ex.Message}");
 
 			lock (_sync)
 			{

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -82,7 +82,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load default location weather: {ex.Message}");
 		}
 	}
@@ -130,7 +130,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			}
 
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load weather for location: {ex.Message}");
 
 			RaiseItemsChanged();
@@ -376,7 +376,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			}
 
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Search network error: {ex.Message}");
 
 			RaiseItemsChanged();
@@ -389,7 +389,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			}
 
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Search error: {ex.Message}");
 
 			RaiseItemsChanged();

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -2,451 +2,445 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Globalization;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Commands;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using System.Globalization;
+using System.Text;
 
 namespace Microsoft.CmdPal.Ext.Weather.Pages;
 
 internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 {
-    private static readonly CompositeFormat NoResultsFormat = CompositeFormat.Parse(Resources.no_results_for);
-    private const int MinSearchLength = 3;
+	private static readonly CompositeFormat NoResultsFormat = CompositeFormat.Parse(Resources.no_results_for);
+	private const int MinSearchLength = 3;
 
-    private readonly IWeatherService _weatherService;
-    private readonly GeocodingService _geocodingService;
-    private readonly WeatherSettingsManager _settingsManager;
-    private readonly PinnedLocationsManager _pinnedLocationsManager;
-    private readonly Lock _sync = new();
-    private readonly CancellationTokenSource _cts = new();
+	private readonly IWeatherService _weatherService;
+	private readonly GeocodingService _geocodingService;
+	private readonly WeatherSettingsManager _settingsManager;
+	private readonly PinnedLocationsManager _pinnedLocationsManager;
+	private readonly Lock _sync = new();
+	private readonly CancellationTokenSource _cts = new();
 
-    private IListItem[] _items = [];
-    private bool _isLoading;
-    private string _lastSearchQuery = string.Empty;
-    private CancellationTokenSource _searchCts = new();
+	private IListItem[] _items = [];
+	private bool _isLoading;
+	private string _lastSearchQuery = string.Empty;
+	private CancellationTokenSource _searchCts = new();
 
-    public WeatherListPage(
-        IWeatherService weatherService,
-        GeocodingService geocodingService,
-        WeatherSettingsManager settingsManager,
-        PinnedLocationsManager pinnedLocationsManager)
-    {
-        ArgumentNullException.ThrowIfNull(weatherService);
-        ArgumentNullException.ThrowIfNull(geocodingService);
-        ArgumentNullException.ThrowIfNull(settingsManager);
-        ArgumentNullException.ThrowIfNull(pinnedLocationsManager);
+	public WeatherListPage(
+		IWeatherService weatherService,
+		GeocodingService geocodingService,
+		WeatherSettingsManager settingsManager,
+		PinnedLocationsManager pinnedLocationsManager)
+	{
+		ArgumentNullException.ThrowIfNull(weatherService);
+		ArgumentNullException.ThrowIfNull(geocodingService);
+		ArgumentNullException.ThrowIfNull(settingsManager);
+		ArgumentNullException.ThrowIfNull(pinnedLocationsManager);
 
-        _weatherService = weatherService;
-        _geocodingService = geocodingService;
-        _settingsManager = settingsManager;
-        _pinnedLocationsManager = pinnedLocationsManager;
+		_weatherService = weatherService;
+		_geocodingService = geocodingService;
+		_settingsManager = settingsManager;
+		_pinnedLocationsManager = pinnedLocationsManager;
 
-        Name = "Weather";
-        Title = "Weather";
-        Icon = Icons.WeatherIcon;
-        Id = "com.baldbeardedbuilder.cmdpal.weather.list";
-        PlaceholderText = Resources.search_placeholder;
-        ShowDetails = true;
+		Name = "Weather";
+		Title = "Weather";
+		Icon = Icons.WeatherIcon;
+		Id = "com.baldbeardedbuilder.cmdpal.weather.list";
+		PlaceholderText = Resources.search_placeholder;
+		ShowDetails = true;
 
-        LoadDefaultLocationWeather();
+		LoadDefaultLocationWeather();
 
-        _settingsManager.Settings.SettingsChanged += OnSettingsChanged;
-    }
+		_settingsManager.Settings.SettingsChanged += OnSettingsChanged;
+	}
 
-    private async void LoadDefaultLocationWeather(CancellationToken searchCt = default)
-    {
-        try
-        {
-            var defaultLocation = _settingsManager.DefaultLocation;
-            if (string.IsNullOrWhiteSpace(defaultLocation))
-            {
-                return;
-            }
+	private async void LoadDefaultLocationWeather(CancellationToken searchCt = default)
+	{
+		try
+		{
+			var defaultLocation = _settingsManager.DefaultLocation;
+			if (string.IsNullOrWhiteSpace(defaultLocation))
+			{
+				return;
+			}
 
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
-            var locations = await _geocodingService.SearchLocationAsync(defaultLocation, linkedCts.Token).ConfigureAwait(false);
-            if (locations.Count > 0)
-            {
-                await LoadWeatherForLocation(locations[0], linkedCts.Token).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when cancelled by a newer search or page is disposed
-        }
-        catch (Exception ex)
-        {
-            ExtensionHost.LogMessage(new LogMessage
-            {
-                Message = $"Failed to load default location weather: {ex.Message}",
-            });
-        }
-    }
+			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
+			var locations = await _geocodingService.SearchLocationAsync(defaultLocation, linkedCts.Token).ConfigureAwait(false);
+			if (locations.Count > 0)
+			{
+				await LoadWeatherForLocation(locations[0], linkedCts.Token).ConfigureAwait(false);
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			// Expected when cancelled by a newer search or page is disposed
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to load default location weather: {ex.Message}");
+		}
+	}
 
-    private async Task LoadWeatherForLocation(GeocodingResult location, CancellationToken ct)
-    {
-        try
-        {
-            var weatherData = await _weatherService.GetCurrentWeatherAsync(
-                location.Latitude,
-                location.Longitude,
-                _settingsManager.TemperatureUnit,
-                _settingsManager.WindSpeedUnit,
-                ct).ConfigureAwait(false);
+	private async Task LoadWeatherForLocation(GeocodingResult location, CancellationToken ct)
+	{
+		try
+		{
+			var weatherData = await _weatherService.GetCurrentWeatherAsync(
+				location.Latitude,
+				location.Longitude,
+				_settingsManager.TemperatureUnit,
+				_settingsManager.WindSpeedUnit,
+				ct).ConfigureAwait(false);
 
-            if (weatherData?.Current == null)
-            {
-                lock (_sync)
-                {
-                    _isLoading = false;
-                }
+			if (weatherData?.Current == null)
+			{
+				lock (_sync)
+				{
+					_isLoading = false;
+				}
 
-                RaiseItemsChanged();
-                return;
-            }
+				RaiseItemsChanged();
+				return;
+			}
 
-            var items = new List<IListItem>
-            {
-                CreateWeatherItem(location, weatherData),
-            };
+			var items = new List<IListItem>
+			{
+				CreateWeatherItem(location, weatherData),
+			};
 
-            lock (_sync)
-            {
-                _items = items.ToArray();
-                _isLoading = false;
-            }
+			lock (_sync)
+			{
+				_items = items.ToArray();
+				_isLoading = false;
+			}
 
-            RaiseItemsChanged();
-        }
-        catch (Exception ex)
-        {
-            lock (_sync)
-            {
-                _isLoading = false;
-            }
+			RaiseItemsChanged();
+		}
+		catch (Exception ex)
+		{
+			lock (_sync)
+			{
+				_isLoading = false;
+			}
 
-            ExtensionHost.LogMessage(new LogMessage
-            {
-                Message = $"Failed to load weather for location: {ex.Message}",
-            });
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to load weather for location: {ex.Message}");
 
-            RaiseItemsChanged();
-        }
-    }
+			RaiseItemsChanged();
+		}
+	}
 
-    private ListItem CreateWeatherItem(GeocodingResult location, WeatherData weatherData)
-    {
-        if (weatherData?.Current == null)
-        {
-            return new ListItem(new NoOpCommand())
-            {
-                Title = location.DisplayName,
-                Subtitle = Resources.no_data_available,
-                Icon = Icons.WeatherIcon,
-            };
-        }
+	private ListItem CreateWeatherItem(GeocodingResult location, WeatherData weatherData)
+	{
+		if (weatherData?.Current == null)
+		{
+			return new ListItem(new NoOpCommand())
+			{
+				Title = location.DisplayName,
+				Subtitle = Resources.no_data_available,
+				Icon = Icons.WeatherIcon,
+			};
+		}
 
-        var current = weatherData.Current;
-        var tempUnit = _settingsManager.TemperatureUnit == "celsius" ? "°C" : "°F";
-        var windUnit = _settingsManager.WindSpeedUnit == "mph" ? "mph" : "km/h";
-        var condition = Icons.GetWeatherDescription(current.WeatherCode);
+		var current = weatherData.Current;
+		var tempUnit = _settingsManager.TemperatureUnit == "celsius" ? "°C" : "°F";
+		var windUnit = _settingsManager.WindSpeedUnit == "mph" ? "mph" : "km/h";
+		var condition = Icons.GetWeatherDescription(current.WeatherCode);
 
-        var detailPage = new WeatherDetailPage(
-            location,
-            _weatherService,
-            _settingsManager);
+		var detailPage = new WeatherDetailPage(
+			location,
+			_weatherService,
+			_settingsManager);
 
-        var moreCommands = new List<ICommandContextItem>
-        {
-            new CommandContextItem(new RefreshWeatherCommand(this)),
-        };
+		var moreCommands = new List<ICommandContextItem>
+		{
+			new CommandContextItem(new RefreshWeatherCommand(this)),
+		};
 
-        if (_pinnedLocationsManager.IsPinned(location))
-        {
-            moreCommands.Add(new CommandContextItem(new UnpinFromDockCommand(location, _pinnedLocationsManager)));
-        }
-        else
-        {
-            moreCommands.Add(new CommandContextItem(new PinToDockCommand(location, _pinnedLocationsManager)));
-        }
+		if (_pinnedLocationsManager.IsPinned(location))
+		{
+			moreCommands.Add(new CommandContextItem(new UnpinFromDockCommand(location, _pinnedLocationsManager)));
+		}
+		else
+		{
+			moreCommands.Add(new CommandContextItem(new PinToDockCommand(location, _pinnedLocationsManager)));
+		}
 
-        var item = new ListItem(detailPage)
-        {
-            Title = location.DisplayName,
-            Subtitle = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
-            Icon = Icons.GetIconForWeatherCode(current.WeatherCode),
-            Details = new Details
-            {
-                Title = location.DisplayName,
-                Body = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
-                Metadata =
-                [
-                    new DetailsElement { Key = "Humidity", Data = new DetailsLink($"{current.RelativeHumidity}%") },
-                    new DetailsElement { Key = "Wind", Data = new DetailsLink($"{current.WindSpeed:F1} {windUnit}") },
-                    new DetailsElement { Key = "Wind Direction", Data = new DetailsLink(GetWindDirection(current.WindDirection)) },
-                ],
-            },
-            MoreCommands = moreCommands.ToArray(),
-        };
+		var item = new ListItem(detailPage)
+		{
+			Title = location.DisplayName,
+			Subtitle = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
+			Icon = Icons.GetIconForWeatherCode(current.WeatherCode),
+			Details = new Details
+			{
+				Title = location.DisplayName,
+				Body = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
+				Metadata =
+				[
+					new DetailsElement { Key = "Humidity", Data = new DetailsLink($"{current.RelativeHumidity}%") },
+					new DetailsElement { Key = "Wind", Data = new DetailsLink($"{current.WindSpeed:F1} {windUnit}") },
+					new DetailsElement { Key = "Wind Direction", Data = new DetailsLink(GetWindDirection(current.WindDirection)) },
+				],
+			},
+			MoreCommands = moreCommands.ToArray(),
+		};
 
-        return item;
-    }
+		return item;
+	}
 
-    private static string GetWindDirection(int degrees)
-    {
-        var directions = new[] { "N", "NE", "E", "SE", "S", "SW", "W", "NW" };
-        var index = (int)Math.Round(degrees / 45.0) % 8;
-        return directions[index];
-    }
+	private static string GetWindDirection(int degrees)
+	{
+		var directions = new[] { "N", "NE", "E", "SE", "S", "SW", "W", "NW" };
+		var index = (int)Math.Round(degrees / 45.0) % 8;
+		return directions[index];
+	}
 
-    public override void UpdateSearchText(string oldSearch, string newSearch)
-    {
-        if (string.IsNullOrWhiteSpace(newSearch))
-        {
-            var ct = ResetSearchToken();
-            _lastSearchQuery = string.Empty;
-            LoadDefaultLocationWeather(ct);
-            return;
-        }
+	public override void UpdateSearchText(string oldSearch, string newSearch)
+	{
+		if (string.IsNullOrWhiteSpace(newSearch))
+		{
+			var ct = ResetSearchToken();
+			_lastSearchQuery = string.Empty;
+			LoadDefaultLocationWeather(ct);
+			return;
+		}
 
-        if (newSearch.Trim().Length < MinSearchLength)
-        {
-            ResetSearchToken();
-            _lastSearchQuery = newSearch;
-            var minCharsItem = new ListItem(new NoOpCommand())
-            {
-                Title = Resources.search_min_chars,
-                Icon = Icons.WeatherIcon,
-            };
-            lock (_sync)
-            {
-                _items = [minCharsItem];
-                _isLoading = false;
-            }
+		if (newSearch.Trim().Length < MinSearchLength)
+		{
+			ResetSearchToken();
+			_lastSearchQuery = newSearch;
+			var minCharsItem = new ListItem(new NoOpCommand())
+			{
+				Title = Resources.search_min_chars,
+				Icon = Icons.WeatherIcon,
+			};
+			lock (_sync)
+			{
+				_items = [minCharsItem];
+				_isLoading = false;
+			}
 
-            RaiseItemsChanged();
-            return;
-        }
+			RaiseItemsChanged();
+			return;
+		}
 
-        if (newSearch == _lastSearchQuery)
-        {
-            return;
-        }
+		if (newSearch == _lastSearchQuery)
+		{
+			return;
+		}
 
-        _lastSearchQuery = newSearch;
-        var searchCt = ResetSearchToken();
-        _ = PerformDebouncedSearchAsync(newSearch, searchCt);
-    }
+		_lastSearchQuery = newSearch;
+		var searchCt = ResetSearchToken();
+		_ = PerformDebouncedSearchAsync(newSearch, searchCt);
+	}
 
-    private CancellationToken ResetSearchToken()
-    {
-        var oldCts = _searchCts;
-        _searchCts = new CancellationTokenSource();
-        // Cancel but do not dispose immediately: the fire-and-forget debounced task may still be
-        // executing callbacks on oldCts.Token, and disposing it while those callbacks are in flight
-        // would throw ObjectDisposedException.  The GC will reclaim it once no references remain.
-        oldCts.Cancel();
-        return _searchCts.Token;
-    }
+	private CancellationToken ResetSearchToken()
+	{
+		var oldCts = _searchCts;
+		_searchCts = new CancellationTokenSource();
+		// Cancel but do not dispose immediately: the fire-and-forget debounced task may still be
+		// executing callbacks on oldCts.Token, and disposing it while those callbacks are in flight
+		// would throw ObjectDisposedException.  The GC will reclaim it once no references remain.
+		oldCts.Cancel();
+		return _searchCts.Token;
+	}
 
-    private async Task PerformDebouncedSearchAsync(string query, CancellationToken searchCt)
-    {
-        try
-        {
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
-            await Task.Delay(300, linkedCts.Token).ConfigureAwait(false);
-            await PerformSearchAsync(query, linkedCts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when the debounce is cancelled by a newer search or page is disposed
-        }
-    }
+	private async Task PerformDebouncedSearchAsync(string query, CancellationToken searchCt)
+	{
+		try
+		{
+			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
+			await Task.Delay(300, linkedCts.Token).ConfigureAwait(false);
+			await PerformSearchAsync(query, linkedCts.Token).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+			// Expected when the debounce is cancelled by a newer search or page is disposed
+		}
+	}
 
-    private async Task PerformSearchAsync(string query, CancellationToken ct)
-    {
-        try
-        {
-            lock (_sync)
-            {
-                _isLoading = true;
-            }
+	private async Task PerformSearchAsync(string query, CancellationToken ct)
+	{
+		try
+		{
+			lock (_sync)
+			{
+				_isLoading = true;
+			}
 
-            RaiseItemsChanged();
+			RaiseItemsChanged();
 
-            var locations = await _geocodingService.SearchLocationAsync(query, ct).ConfigureAwait(false);
+			var locations = await _geocodingService.SearchLocationAsync(query, ct).ConfigureAwait(false);
 
-            // Re-check cancellation after the async call returns so that stale results
-            // from an earlier query are never shown when the user has already typed more.
-            if (ct.IsCancellationRequested)
-            {
-                lock (_sync)
-                {
-                    _isLoading = false;
-                }
+			// Re-check cancellation after the async call returns so that stale results
+			// from an earlier query are never shown when the user has already typed more.
+			if (ct.IsCancellationRequested)
+			{
+				lock (_sync)
+				{
+					_isLoading = false;
+				}
 
-                RaiseItemsChanged();
-                return;
-            }
+				RaiseItemsChanged();
+				return;
+			}
 
-            if (locations.Count == 0)
-            {
-                var noResultsItem = new ListItem(new NoOpCommand())
-                {
-                    Title = Resources.no_locations_found,
-                    Subtitle = string.Format(CultureInfo.CurrentCulture, NoResultsFormat, query),
-                    Icon = Icons.WeatherIcon,
-                };
+			if (locations.Count == 0)
+			{
+				var noResultsItem = new ListItem(new NoOpCommand())
+				{
+					Title = Resources.no_locations_found,
+					Subtitle = string.Format(CultureInfo.CurrentCulture, NoResultsFormat, query),
+					Icon = Icons.WeatherIcon,
+				};
 
-                lock (_sync)
-                {
-                    _items = [noResultsItem];
-                    _isLoading = false;
-                }
+				lock (_sync)
+				{
+					_items = [noResultsItem];
+					_isLoading = false;
+				}
 
-                RaiseItemsChanged();
-                return;
-            }
+				RaiseItemsChanged();
+				return;
+			}
 
-            if (locations.Count == 1)
-            {
-                await LoadWeatherForLocation(locations[0], ct).ConfigureAwait(false);
-                return;
-            }
+			if (locations.Count == 1)
+			{
+				await LoadWeatherForLocation(locations[0], ct).ConfigureAwait(false);
+				return;
+			}
 
-            var items = new List<IListItem>();
-            foreach (var location in locations.Take(10))
-            {
-                var weatherData = await _weatherService.GetCurrentWeatherAsync(
-                    location.Latitude,
-                    location.Longitude,
-                    _settingsManager.TemperatureUnit,
-                    _settingsManager.WindSpeedUnit,
-                    ct).ConfigureAwait(false);
+			var items = new List<IListItem>();
+			foreach (var location in locations.Take(10))
+			{
+				var weatherData = await _weatherService.GetCurrentWeatherAsync(
+					location.Latitude,
+					location.Longitude,
+					_settingsManager.TemperatureUnit,
+					_settingsManager.WindSpeedUnit,
+					ct).ConfigureAwait(false);
 
-                if (weatherData != null)
-                {
-                    items.Add(CreateWeatherItem(location, weatherData));
-                }
-            }
+				if (weatherData != null)
+				{
+					items.Add(CreateWeatherItem(location, weatherData));
+				}
+			}
 
-            // Final cancellation check before committing results to the UI.
-            if (ct.IsCancellationRequested)
-            {
-                lock (_sync)
-                {
-                    _isLoading = false;
-                }
+			// Final cancellation check before committing results to the UI.
+			if (ct.IsCancellationRequested)
+			{
+				lock (_sync)
+				{
+					_isLoading = false;
+				}
 
-                RaiseItemsChanged();
-                return;
-            }
+				RaiseItemsChanged();
+				return;
+			}
 
-            lock (_sync)
-            {
-                _items = items.ToArray();
-                _isLoading = false;
-            }
+			lock (_sync)
+			{
+				_items = items.ToArray();
+				_isLoading = false;
+			}
 
-            RaiseItemsChanged();
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when the search is cancelled by a newer query or page is disposed
-            lock (_sync)
-            {
-                _isLoading = false;
-            }
+			RaiseItemsChanged();
+		}
+		catch (OperationCanceledException)
+		{
+			// Expected when the search is cancelled by a newer query or page is disposed
+			lock (_sync)
+			{
+				_isLoading = false;
+			}
 
-            RaiseItemsChanged();
-        }
-        catch (HttpRequestException ex)
-        {
-            lock (_sync)
-            {
-                _isLoading = false;
-                _items = [new ListItem(new NoOpCommand())
-                {
-                    Title = Resources.network_error,
-                    Icon = Icons.WeatherIcon,
-                }];
-            }
+			RaiseItemsChanged();
+		}
+		catch (HttpRequestException ex)
+		{
+			lock (_sync)
+			{
+				_isLoading = false;
+				_items = [new ListItem(new NoOpCommand())
+				{
+					Title = Resources.network_error,
+					Icon = Icons.WeatherIcon,
+				}];
+			}
 
-            ExtensionHost.LogMessage(new LogMessage
-            {
-                Message = $"Search network error: {ex.Message}",
-            });
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Search network error: {ex.Message}");
 
-            RaiseItemsChanged();
-        }
-        catch (Exception ex)
-        {
-            lock (_sync)
-            {
-                _isLoading = false;
-            }
+			RaiseItemsChanged();
+		}
+		catch (Exception ex)
+		{
+			lock (_sync)
+			{
+				_isLoading = false;
+			}
 
-            ExtensionHost.LogMessage(new LogMessage
-            {
-                Message = $"Search error: {ex.Message}",
-            });
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Search error: {ex.Message}");
 
-            RaiseItemsChanged();
-        }
-    }
+			RaiseItemsChanged();
+		}
+	}
 
-    private void OnSettingsChanged(object sender, Settings args)
-    {
-        RefreshWeather();
-    }
+	private void OnSettingsChanged(object sender, Settings args)
+	{
+		RefreshWeather();
+	}
 
-    public void RefreshWeather()
-    {
-        var ct = ResetSearchToken();
-        if (!string.IsNullOrWhiteSpace(_lastSearchQuery))
-        {
-            _ = PerformDebouncedSearchAsync(_lastSearchQuery, ct);
-        }
-        else
-        {
-            LoadDefaultLocationWeather(ct);
-        }
-    }
+	public void RefreshWeather()
+	{
+		var ct = ResetSearchToken();
+		if (!string.IsNullOrWhiteSpace(_lastSearchQuery))
+		{
+			_ = PerformDebouncedSearchAsync(_lastSearchQuery, ct);
+		}
+		else
+		{
+			LoadDefaultLocationWeather(ct);
+		}
+	}
 
-    public override IListItem[] GetItems()
-    {
-        lock (_sync)
-        {
-            if (_isLoading)
-            {
-                return
-                [
-                    new ListItem(new NoOpCommand())
-                    {
-                        Title = Resources.loading_data,
-                        Icon = Icons.WeatherIcon,
-                    },
-                ];
-            }
+	public override IListItem[] GetItems()
+	{
+		lock (_sync)
+		{
+			if (_isLoading)
+			{
+				return
+				[
+					new ListItem(new NoOpCommand())
+					{
+						Title = Resources.loading_data,
+						Icon = Icons.WeatherIcon,
+					},
+				];
+			}
 
-            return _items;
-        }
-    }
+			return _items;
+		}
+	}
 
-    public void Dispose()
-    {
-        _settingsManager.Settings.SettingsChanged -= OnSettingsChanged;
-        _searchCts?.Cancel();
-        _searchCts?.Dispose();
-        _cts?.Cancel();
-        _cts?.Dispose();
-        GC.SuppressFinalize(this);
-    }
+	public void Dispose()
+	{
+		_settingsManager.Settings.SettingsChanged -= OnSettingsChanged;
+		_searchCts?.Cancel();
+		_searchCts?.Dispose();
+		_cts?.Cancel();
+		_cts?.Dispose();
+		GC.SuppressFinalize(this);
+	}
 }

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -4,6 +4,7 @@
 
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -78,7 +79,7 @@ public sealed partial class GeocodingService : IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Geocoding error: {ex.Message}");
 			return [];
 		}
@@ -140,7 +141,7 @@ public sealed partial class GeocodingService : IDisposable
 			if (nominatimResults == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 				return [];
 			}
@@ -155,7 +156,7 @@ public sealed partial class GeocodingService : IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Nominatim postal code lookup error: {ex.Message}");
 			return [];
 		}
@@ -169,7 +170,7 @@ public sealed partial class GeocodingService : IDisposable
 		if (!response.IsSuccessStatusCode)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Info,
+				MessageState.Info,
 				$"Nominatim API returned status {response.StatusCode}: {response.RequestMessage}, query: {query}");
 			return [];
 		}
@@ -180,7 +181,7 @@ public sealed partial class GeocodingService : IDisposable
 		if (nominatimResults == null)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Info,
+				MessageState.Info,
 				$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}, Query: {query}");
 			return [];
 		}

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -2,8 +2,8 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -77,10 +77,9 @@ public sealed partial class GeocodingService : IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Geocoding error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Geocoding error: {ex.Message}");
 			return [];
 		}
 	}
@@ -140,10 +139,9 @@ public sealed partial class GeocodingService : IDisposable
 
 			if (nominatimResults == null)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Info,
+					$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 				return [];
 			}
 
@@ -156,10 +154,9 @@ public sealed partial class GeocodingService : IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Nominatim postal code lookup error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Nominatim postal code lookup error: {ex.Message}");
 			return [];
 		}
 	}
@@ -171,10 +168,9 @@ public sealed partial class GeocodingService : IDisposable
 
 		if (!response.IsSuccessStatusCode)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Nominatim API returned status {response.StatusCode}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Info,
+				$"Nominatim API returned status {response.StatusCode}: {response.RequestMessage}, query: {query}");
 			return [];
 		}
 
@@ -183,10 +179,9 @@ public sealed partial class GeocodingService : IDisposable
 
 		if (nominatimResults == null)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Info,
+				$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}, Query: {query}");
 			return [];
 		}
 

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -171,7 +171,7 @@ public sealed partial class GeocodingService : IDisposable
 		{
 			WeatherLogger.LogToHost(
 				MessageState.Info,
-				$"Nominatim API returned status {response.StatusCode}: {response.RequestMessage}, query: {query}");
+				$"Nominatim API returned status {response.StatusCode}");
 			return [];
 		}
 
@@ -182,7 +182,7 @@ public sealed partial class GeocodingService : IDisposable
 		{
 			WeatherLogger.LogToHost(
 				MessageState.Info,
-				$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}, Query: {query}");
+				$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			return [];
 		}
 

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -78,7 +79,7 @@ public sealed partial class GeocodingService : IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Geocoding error: {ex.Message}");
 			return [];
 		}
@@ -140,7 +141,7 @@ public sealed partial class GeocodingService : IDisposable
 			if (nominatimResults == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 				return [];
 			}
@@ -155,7 +156,7 @@ public sealed partial class GeocodingService : IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Nominatim postal code lookup error: {ex.Message}");
 			return [];
 		}
@@ -169,7 +170,7 @@ public sealed partial class GeocodingService : IDisposable
 		if (!response.IsSuccessStatusCode)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Info,
+				MessageState.Info,
 				$"Nominatim API returned status {response.StatusCode}: {response.RequestMessage}, query: {query}");
 			return [];
 		}
@@ -180,7 +181,7 @@ public sealed partial class GeocodingService : IDisposable
 		if (nominatimResults == null)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Info,
+				MessageState.Info,
 				$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}, Query: {query}");
 			return [];
 		}

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using System.Text.Json;
 
@@ -61,7 +62,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Weather API returned status {response.StatusCode}");
 				return null;
 			}
@@ -72,7 +73,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (weatherData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Weather deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -88,7 +89,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Weather fetch error: {ex.Message}");
 			return null;
 		}
@@ -119,7 +120,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Forecast API returned status {response.StatusCode}");
 				return null;
 			}
@@ -130,7 +131,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (forecastData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -146,7 +147,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Forecast fetch error: {ex.Message}");
 			return null;
 		}
@@ -178,7 +179,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Hourly forecast API returned status {response.StatusCode}");
 				return null;
 			}
@@ -189,7 +190,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (hourlyData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Hourly forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -205,7 +206,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Hourly forecast fetch error: {ex.Message}");
 			return null;
 		}

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -2,8 +2,8 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using System.Text.Json;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
@@ -60,10 +60,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (!response.IsSuccessStatusCode)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Weather API returned status {response.StatusCode}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Error,
+					$"Weather API returned status {response.StatusCode}");
 				return null;
 			}
 
@@ -72,10 +71,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (weatherData == null)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Weather deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Info,
+					$"Weather deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
 			if (weatherData != null)
@@ -89,10 +87,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Weather fetch error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Weather fetch error: {ex.Message}");
 			return null;
 		}
 	}
@@ -121,10 +118,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (!response.IsSuccessStatusCode)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Forecast API returned status {response.StatusCode}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Error,
+					$"Forecast API returned status {response.StatusCode}");
 				return null;
 			}
 
@@ -133,10 +129,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (forecastData == null)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Info,
+					$"Forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
 			if (forecastData != null)
@@ -150,10 +145,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Forecast fetch error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Forecast fetch error: {ex.Message}");
 			return null;
 		}
 	}
@@ -183,10 +177,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (!response.IsSuccessStatusCode)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Hourly forecast API returned status {response.StatusCode}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Error,
+					$"Hourly forecast API returned status {response.StatusCode}");
 				return null;
 			}
 
@@ -195,10 +188,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			if (hourlyData == null)
 			{
-				ExtensionHost.LogMessage(new LogMessage
-				{
-					Message = $"Hourly forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}",
-				});
+				WeatherLogger.LogToHost(
+					CommandPalette.Extensions.MessageState.Info,
+					$"Hourly forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
 			if (hourlyData != null)
@@ -212,10 +204,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Hourly forecast fetch error: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Hourly forecast fetch error: {ex.Message}");
 			return null;
 		}
 	}

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -4,6 +4,7 @@
 
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
@@ -61,7 +62,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Weather API returned status {response.StatusCode}");
 				return null;
 			}
@@ -72,7 +73,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (weatherData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Weather deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -88,7 +89,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Weather fetch error: {ex.Message}");
 			return null;
 		}
@@ -119,7 +120,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Forecast API returned status {response.StatusCode}");
 				return null;
 			}
@@ -130,7 +131,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (forecastData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -146,7 +147,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Forecast fetch error: {ex.Message}");
 			return null;
 		}
@@ -178,7 +179,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (!response.IsSuccessStatusCode)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Error,
+					MessageState.Error,
 					$"Hourly forecast API returned status {response.StatusCode}");
 				return null;
 			}
@@ -189,7 +190,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 			if (hourlyData == null)
 			{
 				WeatherLogger.LogToHost(
-					CommandPalette.Extensions.MessageState.Info,
+					MessageState.Info,
 					$"Hourly forecast deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
 			}
 
@@ -205,7 +206,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Hourly forecast fetch error: {ex.Message}");
 			return null;
 		}

--- a/WeatherExtension/Services/PinnedLocationsManager.cs
+++ b/WeatherExtension/Services/PinnedLocationsManager.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using System.Text.Json;
 
@@ -115,7 +116,7 @@ public sealed class PinnedLocationsManager
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load pinned locations: {ex.Message}");
 		}
 	}
@@ -130,7 +131,7 @@ public sealed class PinnedLocationsManager
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to save pinned locations: {ex.Message}");
 		}
 	}

--- a/WeatherExtension/Services/PinnedLocationsManager.cs
+++ b/WeatherExtension/Services/PinnedLocationsManager.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using BaldBeardedBuilder.WeatherExtension;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;

--- a/WeatherExtension/Services/PinnedLocationsManager.cs
+++ b/WeatherExtension/Services/PinnedLocationsManager.cs
@@ -2,10 +2,9 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Text.Json;
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
-using Microsoft.CommandPalette.Extensions.Toolkit;
+using System.Text.Json;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
 
@@ -115,10 +114,9 @@ public sealed class PinnedLocationsManager
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Failed to load pinned locations: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to load pinned locations: {ex.Message}");
 		}
 	}
 
@@ -131,10 +129,9 @@ public sealed class PinnedLocationsManager
 		}
 		catch (Exception ex)
 		{
-			ExtensionHost.LogMessage(new LogMessage
-			{
-				Message = $"Failed to save pinned locations: {ex.Message}",
-			});
+			WeatherLogger.LogToHost(
+				CommandPalette.Extensions.MessageState.Error,
+				$"Failed to save pinned locations: {ex.Message}");
 		}
 	}
 }

--- a/WeatherExtension/Services/PinnedLocationsManager.cs
+++ b/WeatherExtension/Services/PinnedLocationsManager.cs
@@ -4,6 +4,7 @@
 
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CommandPalette.Extensions;
 using System.Text.Json;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
@@ -115,7 +116,7 @@ public sealed class PinnedLocationsManager
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to load pinned locations: {ex.Message}");
 		}
 	}
@@ -130,7 +131,7 @@ public sealed class PinnedLocationsManager
 		catch (Exception ex)
 		{
 			WeatherLogger.LogToHost(
-				CommandPalette.Extensions.MessageState.Error,
+				MessageState.Error,
 				$"Failed to save pinned locations: {ex.Message}");
 		}
 	}

--- a/WeatherExtension/WeatherLogger.cs
+++ b/WeatherExtension/WeatherLogger.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace BaldBeardedBuilder.WeatherExtension;
+
+internal static class WeatherLogger
+{
+	internal static void LogToHost(MessageState state, string message)
+	{
+		ExtensionHost.LogMessage(new LogMessage
+		{
+			Message = message,
+			State = state,
+		});
+	}
+}


### PR DESCRIPTION
This pull request refactors error and info logging throughout the WeatherExtension project to use a centralized `WeatherLogger.LogToHost` method instead of directly calling `ExtensionHost.LogMessage`. This change standardizes how log messages are handled, improves code consistency, and makes it easier to manage logging behavior across the codebase.

**Centralized Logging Refactor:**

- Replaced all usages of `ExtensionHost.LogMessage` with `WeatherLogger.LogToHost`, passing appropriate `MessageState` and error/info messages in all weather band, page, and service classes. This applies to network errors, deserialization issues, and general exception handling. [[1]](diffhunk://#diff-d9aecf79ee06a4505ff1c79dbd1404c55b6fe9d0bcbbd499708d700e359933bcL126-R128) [[2]](diffhunk://#diff-d9aecf79ee06a4505ff1c79dbd1404c55b6fe9d0bcbbd499708d700e359933bcL139-R140) [[3]](diffhunk://#diff-cc6183a6360c1494b82bf0c244fe32c267b90cc9c064d33d70b4c1dcbae2f803L112-R114) [[4]](diffhunk://#diff-cc6183a6360c1494b82bf0c244fe32c267b90cc9c064d33d70b4c1dcbae2f803L125-R126) [[5]](diffhunk://#diff-6d6ce6e55ef055673bd5e57f4dc3f74eacad21bfa90e44d788669de201f7f463L74-R77) [[6]](diffhunk://#diff-b6922f7b61b596692c7c5ef755ebbba86b023cf4eab36e0fbedf4558741b5b14L99-R101) [[7]](diffhunk://#diff-01eb68c7ae756a86f3ec1d3c1fa2103e8c1cffe05dbb84a3e9038e7853264aeeL88-R91) [[8]](diffhunk://#diff-a1254388f96eecf70c450cc4104c2b5a3dc8529ce4e29b340f0459d5eb1aa8b8L86-R86) [[9]](diffhunk://#diff-a1254388f96eecf70c450cc4104c2b5a3dc8529ce4e29b340f0459d5eb1aa8b8L135-R134) [[10]](diffhunk://#diff-a1254388f96eecf70c450cc4104c2b5a3dc8529ce4e29b340f0459d5eb1aa8b8L382-R380) [[11]](diffhunk://#diff-a1254388f96eecf70c450cc4104c2b5a3dc8529ce4e29b340f0459d5eb1aa8b8L396-R393) [[12]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aL80-R82) [[13]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aL143-R144) [[14]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aL159-R159) [[15]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aL174-R173) [[16]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aL186-R184) [[17]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L63-R65) [[18]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L75-R76) [[19]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L92-R92) [[20]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L124-R123) [[21]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L136-R134) [[22]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L153-R150) [[23]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L186-R182) [[24]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604L198-R193)

**Code Cleanup and Organization:**

- Updated `using` directives to include `BaldBeardedBuilder.WeatherExtension` where needed and removed unused imports, improving code clarity and maintainability. [[1]](diffhunk://#diff-d9aecf79ee06a4505ff1c79dbd1404c55b6fe9d0bcbbd499708d700e359933bcL5-R5) [[2]](diffhunk://#diff-cc6183a6360c1494b82bf0c244fe32c267b90cc9c064d33d70b4c1dcbae2f803L5-R5) [[3]](diffhunk://#diff-6d6ce6e55ef055673bd5e57f4dc3f74eacad21bfa90e44d788669de201f7f463R5) [[4]](diffhunk://#diff-b6922f7b61b596692c7c5ef755ebbba86b023cf4eab36e0fbedf4558741b5b14R5-L10) [[5]](diffhunk://#diff-01eb68c7ae756a86f3ec1d3c1fa2103e8c1cffe05dbb84a3e9038e7853264aeeR5) [[6]](diffhunk://#diff-a1254388f96eecf70c450cc4104c2b5a3dc8529ce4e29b340f0459d5eb1aa8b8L5-R12) [[7]](diffhunk://#diff-8d89006043ec1391d8798a0a230d297b3101ee6e01f19317f8747adde76e514aR5-L6) [[8]](diffhunk://#diff-d64734723abff6fa7ab2b87f658c40e1af4c8373791be2c986fb0bbad5559604R5-L6)

These changes make logging more robust and easier to maintain, while also cleaning up the codebase for future development.