### PR TITLE
Add Photon (Komoot) as fallback geocoding provider

### DIFF
--- a/WeatherExtension.Tests/ConvertPhotonResultsTests.cs
+++ b/WeatherExtension.Tests/ConvertPhotonResultsTests.cs
@@ -1,0 +1,313 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class ConvertPhotonResultsTests
+{
+	// ── helpers ─────────────────────────────────────────────────────────────
+
+	private static PhotonFeature MakeFeature(
+		double lon,
+		double lat,
+		string? name = "TestCity",
+		string? city = null,
+		string? state = null,
+		string? county = null,
+		string? country = null,
+		string? countryCode = null,
+		long? osmId = null,
+		string? osmValue = null,
+		double[]? coordsOverride = null)
+	{
+		return new PhotonFeature
+		{
+			Geometry = new PhotonGeometry
+			{
+				Coordinates = coordsOverride ?? [lon, lat],
+			},
+			Properties = new PhotonProperties
+			{
+				Name = name,
+				City = city,
+				State = state,
+				County = county,
+				Country = country,
+				CountryCode = countryCode,
+				OsmId = osmId,
+				OsmValue = osmValue,
+			},
+		};
+	}
+
+	// ── basic field mapping ──────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithCityOnlyFeature_ReturnsSingleResultWithName()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: "Birmingham"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Birmingham", results[0].Name);
+		Assert.IsNull(results[0].Admin1);
+		Assert.IsNull(results[0].Country);
+	}
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithFullProperties_MapsAllFieldsCorrectly()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(
+				lon: -86.80,
+				lat: 33.52,
+				name: "Birmingham",
+				state: "Alabama",
+				county: "Jefferson County",
+				country: "United States",
+				countryCode: "US",
+				osmId: 111031),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		var r = results[0];
+		Assert.AreEqual("Birmingham", r.Name);
+		Assert.AreEqual("Alabama", r.Admin1);
+		Assert.AreEqual("Jefferson County", r.Admin2);
+		Assert.AreEqual("United States", r.Country);
+		Assert.AreEqual("US", r.CountryCode);
+		Assert.AreEqual(111031L, r.Id);
+	}
+
+	// ── CRITICAL: coordinate order ───────────────────────────────────────────
+
+	/// <summary>
+	/// GeoJSON encodes coordinates as [longitude, latitude].
+	/// This test uses an asymmetric pair (10.5 != 20.5) so a swap bug cannot
+	/// accidentally produce a passing test.
+	/// </summary>
+	[TestMethod]
+	public void ConvertPhotonResults_GeoJsonCoordinates_LongitudeIsIndex0LatitudeIsIndex1()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: 10.5, lat: 20.5, name: "Anywhere"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual(10.5, results[0].Longitude, "Longitude must come from coordinates[0].");
+		Assert.AreEqual(20.5, results[0].Latitude, "Latitude must come from coordinates[1].");
+	}
+
+	// ── postcode feature ─────────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithPostcodeFeature_ReturnsResultWithPostcodeAsName()
+	{
+		// When placesOnly=false (postal-code path), postcode entries come through.
+		// Properties.Name holds the postcode string; City is absent.
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: "35201", city: null, osmValue: "postcode"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("35201", results[0].Name);
+	}
+
+	// ── Name fallback to City ────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithNullNameAndCitySet_UsesCityAsName()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: null, city: "Birmingham"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Birmingham", results[0].Name);
+	}
+
+	// ── OsmId fallback ───────────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithNullOsmId_SetsIdToZero()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: "Birmingham", osmId: null),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual(0L, results[0].Id);
+	}
+
+	// ── CountryCode casing ───────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithLowercaseCountryCode_ReturnsUppercased()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -0.09, lat: 51.50, name: "London", countryCode: "gb"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("GB", results[0].CountryCode);
+	}
+
+	// ── empty input ──────────────────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithEmptyList_ReturnsEmptyList()
+	{
+		var results = GeocodingService.ConvertPhotonResults([]);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	// ── skip rules (individual) ──────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithNullGeometry_SkipsFeature()
+	{
+		var features = new List<PhotonFeature>
+		{
+			new() { Geometry = null, Properties = new PhotonProperties { Name = "Nowhere" } },
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithSingleCoordinate_SkipsFeature()
+	{
+		var features = new List<PhotonFeature>
+		{
+			new()
+			{
+				Geometry = new PhotonGeometry { Coordinates = [42.0] },
+				Properties = new PhotonProperties { Name = "Nowhere" },
+			},
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithNullCoordinates_SkipsFeature()
+	{
+		var features = new List<PhotonFeature>
+		{
+			new()
+			{
+				Geometry = new PhotonGeometry { Coordinates = null },
+				Properties = new PhotonProperties { Name = "Nowhere" },
+			},
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithNullNameAndNullCity_SkipsFeature()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: null, city: null),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithWhitespaceNameAndNullCity_SkipsFeature()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: "   ", city: null),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	// ── combined invalid + valid ─────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithMixedValidAndInvalidFeatures_ReturnsOnlyValid()
+	{
+		var features = new List<PhotonFeature>
+		{
+			// (a) null Geometry
+			new() { Geometry = null, Properties = new PhotonProperties { Name = "Ghost A" } },
+			// (b) only one coordinate
+			new()
+			{
+				Geometry = new PhotonGeometry { Coordinates = [-86.0] },
+				Properties = new PhotonProperties { Name = "Ghost B" },
+			},
+			// (c) no usable name -- both Name and City are null
+			MakeFeature(lon: -86.80, lat: 33.52, name: null, city: null),
+			// (d) valid
+			MakeFeature(lon: -86.80, lat: 33.52, name: "Birmingham", state: "Alabama", country: "United States"),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Birmingham", results[0].Name);
+	}
+
+	// ── multiple valid features ──────────────────────────────────────────────
+
+	[TestMethod]
+	public void ConvertPhotonResults_WithMultipleValidFeatures_ReturnsAllInOrder()
+	{
+		var features = new List<PhotonFeature>
+		{
+			MakeFeature(lon: -86.80, lat: 33.52, name: "Birmingham", state: "Alabama", countryCode: "US", osmId: 1),
+			MakeFeature(lon: -1.90, lat: 52.48, name: "Birmingham", state: "England", countryCode: "GB", osmId: 2),
+		};
+
+		var results = GeocodingService.ConvertPhotonResults(features);
+
+		Assert.AreEqual(2, results.Count);
+		Assert.AreEqual("Alabama", results[0].Admin1);
+		Assert.AreEqual("England", results[1].Admin1);
+	}
+}

--- a/WeatherExtension/Models/PhotonFeature.cs
+++ b/WeatherExtension/Models/PhotonFeature.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.CmdPal.Ext.Weather.Models;
+
+public sealed class PhotonFeature
+{
+	[JsonPropertyName("geometry")]
+	public PhotonGeometry? Geometry { get; set; }
+
+	[JsonPropertyName("properties")]
+	public PhotonProperties? Properties { get; set; }
+}
+
+public sealed class PhotonGeometry
+{
+	// GeoJSON coordinates are [longitude, latitude] — note the reversed order vs. convention.
+	[JsonPropertyName("coordinates")]
+	public double[]? Coordinates { get; set; }
+}
+
+public sealed class PhotonProperties
+{
+	[JsonPropertyName("osm_id")]
+	public long? OsmId { get; set; }
+
+	[JsonPropertyName("name")]
+	public string? Name { get; set; }
+
+	[JsonPropertyName("city")]
+	public string? City { get; set; }
+
+	[JsonPropertyName("state")]
+	public string? State { get; set; }
+
+	[JsonPropertyName("county")]
+	public string? County { get; set; }
+
+	[JsonPropertyName("country")]
+	public string? Country { get; set; }
+
+	[JsonPropertyName("countrycode")]
+	public string? CountryCode { get; set; }
+
+	[JsonPropertyName("postcode")]
+	public string? Postcode { get; set; }
+
+	[JsonPropertyName("osm_value")]
+	public string? OsmValue { get; set; }
+}

--- a/WeatherExtension/Models/PhotonFeature.cs
+++ b/WeatherExtension/Models/PhotonFeature.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.Ext.Weather.Models;
 
-public sealed class PhotonFeature
+internal sealed class PhotonFeature
 {
 	[JsonPropertyName("geometry")]
 	public PhotonGeometry? Geometry { get; set; }
@@ -15,14 +15,14 @@ public sealed class PhotonFeature
 	public PhotonProperties? Properties { get; set; }
 }
 
-public sealed class PhotonGeometry
+internal sealed class PhotonGeometry
 {
 	// GeoJSON coordinates are [longitude, latitude] — note the reversed order vs. convention.
 	[JsonPropertyName("coordinates")]
 	public double[]? Coordinates { get; set; }
 }
 
-public sealed class PhotonProperties
+internal sealed class PhotonProperties
 {
 	[JsonPropertyName("osm_id")]
 	public long? OsmId { get; set; }

--- a/WeatherExtension/Models/PhotonResult.cs
+++ b/WeatherExtension/Models/PhotonResult.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.Ext.Weather.Models;
 
-public sealed class PhotonResult
+internal sealed class PhotonResult
 {
 	[JsonPropertyName("features")]
 	public List<PhotonFeature>? Features { get; set; }

--- a/WeatherExtension/Models/PhotonResult.cs
+++ b/WeatherExtension/Models/PhotonResult.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.CmdPal.Ext.Weather.Models;
+
+public sealed class PhotonResult
+{
+	[JsonPropertyName("features")]
+	public List<PhotonFeature>? Features { get; set; }
+}

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -14,6 +14,7 @@ public sealed partial class GeocodingService : IDisposable
 {
 	private readonly HttpClient _httpClient;
 	private const string NominatimUrl = "https://nominatim.openstreetmap.org/search";
+	private const string PhotonUrl = "https://photon.komoot.io/api/";
 	private const int MinSearchLength = 3;
 	internal const int MaxFallbackAttempts = 3;
 
@@ -94,12 +95,31 @@ public sealed partial class GeocodingService : IDisposable
 		{
 			ct.ThrowIfCancellationRequested();
 
-			var results = await SearchNominatimAsync(currentQuery, ct).ConfigureAwait(false);
+			List<GeocodingResult> results;
+			try
+			{
+				results = await SearchNominatimAsync(currentQuery, ct).ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				WeatherLogger.LogToHost(
+					MessageState.Info,
+					$"Nominatim search failed, trying Photon: {ex.Message}");
+				results = [];
+			}
+
 			attempts++;
 
 			if (results.Count > 0)
 			{
 				return results;
+			}
+
+			// Nominatim returned empty or failed — try Photon for the same query before stripping.
+			var photonResults = await SearchPhotonAsync(currentQuery, placesOnly: true, ct).ConfigureAwait(false);
+			if (photonResults.Count > 0)
+			{
+				return photonResults;
 			}
 
 			// Strip the last comma-separated segment and retry
@@ -132,7 +152,7 @@ public sealed partial class GeocodingService : IDisposable
 
 			if (!response.IsSuccessStatusCode)
 			{
-				return [];
+				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
 			}
 
 			var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
@@ -143,12 +163,12 @@ public sealed partial class GeocodingService : IDisposable
 				WeatherLogger.LogToHost(
 					MessageState.Info,
 					$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
-				return [];
+				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
 			}
 
 			if (nominatimResults.Count == 0)
 			{
-				return [];
+				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
 			}
 
 			return ConvertNominatimResults(nominatimResults);
@@ -158,7 +178,7 @@ public sealed partial class GeocodingService : IDisposable
 			WeatherLogger.LogToHost(
 				MessageState.Error,
 				$"Nominatim postal code lookup error: {ex.Message}");
-			return [];
+			return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
 		}
 	}
 
@@ -187,6 +207,89 @@ public sealed partial class GeocodingService : IDisposable
 		}
 
 		return ConvertNominatimResults(nominatimResults);
+	}
+
+	private async Task<List<GeocodingResult>> SearchPhotonAsync(string query, bool placesOnly, CancellationToken ct)
+	{
+		try
+		{
+			var url = $"{PhotonUrl}?q={Uri.EscapeDataString(query)}&limit=10";
+			if (placesOnly)
+			{
+				url += "&osm_tag=place";
+			}
+
+			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				WeatherLogger.LogToHost(
+					MessageState.Info,
+					$"Photon API returned status {response.StatusCode}");
+				return [];
+			}
+
+			var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+			var result = JsonSerializer.Deserialize<PhotonResult>(content, WeatherJsonContext.Default.PhotonResult);
+
+			if (result == null)
+			{
+				WeatherLogger.LogToHost(
+					MessageState.Info,
+					$"Photon deserialization returned null. Content length: {content.Length}");
+				return [];
+			}
+
+			return ConvertPhotonResults(result.Features ?? []);
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Error,
+				$"Photon geocoding error: {ex.Message}");
+			return [];
+		}
+	}
+
+	internal static List<GeocodingResult> ConvertPhotonResults(List<PhotonFeature> features)
+	{
+		var results = new List<GeocodingResult>();
+
+		foreach (var feature in features)
+		{
+			var coords = feature.Geometry?.Coordinates;
+			if (coords == null || coords.Length < 2)
+			{
+				continue;
+			}
+
+			var name = feature.Properties?.Name
+				?? feature.Properties?.City;
+
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				// Skip entries that don't have a usable place name to avoid blank items and unstable ranking.
+				continue;
+			}
+
+			// GeoJSON uses [longitude, latitude] order — swapped from what most people expect.
+			var longitude = coords[0];
+			var latitude = coords[1];
+
+			results.Add(new GeocodingResult
+			{
+				Id = feature.Properties?.OsmId ?? 0,
+				Latitude = latitude,
+				Longitude = longitude,
+				Name = name,
+				Admin1 = feature.Properties?.State,
+				Admin2 = feature.Properties?.County,
+				Country = feature.Properties?.Country,
+				CountryCode = feature.Properties?.CountryCode?.ToUpperInvariant(),
+			});
+		}
+
+		return results;
 	}
 
 	internal static List<GeocodingResult> ConvertNominatimResults(List<NominatimResult> nominatimResults)

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -89,34 +89,51 @@ public sealed partial class GeocodingService : IDisposable
 	private async Task<List<GeocodingResult>> SearchWithProgressiveFallbackAsync(string query, CancellationToken ct)
 	{
 		var currentQuery = query;
-		var attempts = 0;
+		// MaxFallbackAttempts caps the total number of outbound HTTP calls across
+		// both Nominatim and Photon combined, not per-provider. Each provider call
+		// consumes one slot from this budget.
+		var remainingCalls = MaxFallbackAttempts;
+		var nominatimAlive = true;
 
-		while (!string.IsNullOrWhiteSpace(currentQuery) && attempts < MaxFallbackAttempts)
+		while (!string.IsNullOrWhiteSpace(currentQuery) && remainingCalls > 0)
 		{
 			ct.ThrowIfCancellationRequested();
 
-			List<GeocodingResult> results;
-			try
+			if (nominatimAlive)
 			{
-				results = await SearchNominatimAsync(currentQuery, ct).ConfigureAwait(false);
-			}
-			catch (Exception ex)
-			{
-				WeatherLogger.LogToHost(
-					MessageState.Info,
-					$"Nominatim search failed, trying Photon: {ex.Message}");
-				results = [];
+				List<GeocodingResult> results;
+				try
+				{
+					results = await SearchNominatimAsync(currentQuery, ct).ConfigureAwait(false);
+				}
+				catch (Exception ex)
+				{
+					WeatherLogger.LogToHost(
+						MessageState.Info,
+						$"Nominatim search failed, switching to Photon: {ex.Message}");
+					results = [];
+					// Don't waste further budget on a provider that just threw — likely blocked.
+					nominatimAlive = false;
+				}
+
+				remainingCalls--;
+
+				if (results.Count > 0)
+				{
+					return results;
+				}
+
+				if (remainingCalls <= 0)
+				{
+					break;
+				}
 			}
 
-			attempts++;
+			ct.ThrowIfCancellationRequested();
 
-			if (results.Count > 0)
-			{
-				return results;
-			}
-
-			// Nominatim returned empty or failed — try Photon for the same query before stripping.
 			var photonResults = await SearchPhotonAsync(currentQuery, placesOnly: true, ct).ConfigureAwait(false);
+			remainingCalls--;
+
 			if (photonResults.Count > 0)
 			{
 				return photonResults;

--- a/WeatherExtension/Services/WeatherJsonContext.cs
+++ b/WeatherExtension/Services/WeatherJsonContext.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CmdPal.Ext.Weather.Services;
 [JsonSerializable(typeof(List<NominatimResult>))]
 [JsonSerializable(typeof(NominatimAddress))]
 [JsonSerializable(typeof(List<PinnedLocation>))]
+[JsonSerializable(typeof(PhotonResult))]
+[JsonSerializable(typeof(PhotonFeature))]
+[JsonSerializable(typeof(List<PhotonFeature>))]
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 internal partial class WeatherJsonContext : JsonSerializerContext
 {


### PR DESCRIPTION
Closes #55

## Summary
Nominatim is blocked or unavailable in some regions, causing all location searches to silently fail there. This adds **Photon (Komoot)** as a fallback geocoding provider that activates when Nominatim returns an exception or empty results.

Photon was selected after live testing of all supported query patterns (research summary in #55). It is keyless, hosted on infrastructure independent of Nominatim, and handles every pattern correctly when called with `osm_tag=place` for free-text and without that filter for postcode-only queries.

## Changes
**New models** (`Microsoft.CmdPal.Ext.Weather.Models`):
- `PhotonResult` — GeoJSON FeatureCollection wrapper
- `PhotonFeature` / `PhotonGeometry` / `PhotonProperties` — feature shape

**Service changes** (`GeocodingService.cs`):
- `SearchWithProgressiveFallbackAsync` — at each iteration, if Nominatim throws or returns empty, tries Photon (`osm_tag=place`) for the same query before stripping the next comma segment.
- `SearchPostalCodeAsync` — every failure path (non-success status, null deserialization, empty list, exception) now falls through to Photon **without** `osm_tag=place` so postcode entries come through.
- New `SearchPhotonAsync(query, placesOnly, ct)` mirrors the Nominatim helper's logging + error patterns.
- New `ConvertPhotonResults` mapper translates GeoJSON to `GeocodingResult` with **explicit `[lon, lat]` → swap → `Latitude/Longitude`** (called out with an inline comment because it's a footgun) and the same skip rules as `ConvertNominatimResults`.

**JSON context** (`WeatherJsonContext.cs`):
- Registered `PhotonResult`, `PhotonFeature`, and `List<PhotonFeature>` for source-gen / AOT-safe deserialization. No reflection-based JSON anywhere.

**Tests** (`WeatherExtension.Tests/ConvertPhotonResultsTests.cs`, MSTest to match the rest of the suite):
14 tests covering:
- Basic field mapping (city-only, full properties)
- **Critical lon/lat swap** using asymmetric coordinates (10.5, 20.5) so a swap regression cannot pass
- Postcode entries (osm_value="postcode")
- Name fallback to City
- CountryCode uppercased
- OsmId null → Id=0
- Empty list → empty result
- Skip rules: null Geometry, single coordinate, null Coordinates, both Name+City null/whitespace
- Mixed valid+invalid input returns only the valid ones
- Multiple valid features preserved in order

## Notes
- Nominatim remains primary so its richer postcode handling is still preferred when available.
- The repo can only be fully built on Windows (cswinrt.exe is required for the WinRT codegen step). C# compilation phase was clean locally; CI on `windows-latest` is the authoritative build/test verdict.

🚬 *I love it when a plan comes together.*

— Hannibal, with B.A. on the wiring and Murdock on the test bench