### PR TITLE
feat: Replace default location with favorites system

### DIFF
--- a/WeatherExtension.Tests/FavoriteCommandTests.cs
+++ b/WeatherExtension.Tests/FavoriteCommandTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.CmdPal.Ext.Weather.Commands;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class FavoriteCommandTests
+{
+    private string _tempFilePath = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"weather-test-fav-cmd-{Guid.NewGuid()}.json");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // FavoriteLocationCommand
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void FavoriteLocationCommand_Invoke_FavoritesLocation()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+        };
+        var command = new FavoriteLocationCommand(location, manager);
+
+        command.Invoke();
+
+        Assert.IsTrue(manager.IsFavorite(location));
+    }
+
+    [TestMethod]
+    public void FavoriteLocationCommand_Invoke_ReturnsKeepOpen()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var command = new FavoriteLocationCommand(location, manager);
+
+        var result = command.Invoke();
+
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public void FavoriteLocationCommand_HasCorrectName()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var command = new FavoriteLocationCommand(location, manager);
+
+        Assert.IsNotNull(command.Name);
+        Assert.IsFalse(string.IsNullOrEmpty(command.Name));
+    }
+
+    [TestMethod]
+    public void FavoriteLocationCommand_HasIcon()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var command = new FavoriteLocationCommand(location, manager);
+
+        Assert.IsNotNull(command.Icon);
+    }
+
+    // ---------------------------------------------------------------
+    // UnfavoriteLocationCommand
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void UnfavoriteLocationCommand_Invoke_UnfavoritesLocation()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Portland",
+            Latitude = 45.5152,
+            Longitude = -122.6784,
+        };
+        manager.Favorite(location);
+
+        var command = new UnfavoriteLocationCommand(location, manager);
+        command.Invoke();
+
+        Assert.IsFalse(manager.IsFavorite(location));
+    }
+
+    [TestMethod]
+    public void UnfavoriteLocationCommand_Invoke_ReturnsKeepOpen()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+        manager.Favorite(location);
+        var command = new UnfavoriteLocationCommand(location, manager);
+
+        var result = command.Invoke();
+
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public void UnfavoriteLocationCommand_HasCorrectName()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+        var command = new UnfavoriteLocationCommand(location, manager);
+
+        Assert.IsNotNull(command.Name);
+        Assert.IsFalse(string.IsNullOrEmpty(command.Name));
+    }
+
+    [TestMethod]
+    public void UnfavoriteLocationCommand_HasIcon()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+        var command = new UnfavoriteLocationCommand(location, manager);
+
+        Assert.IsNotNull(command.Icon);
+    }
+
+    // ---------------------------------------------------------------
+    // Integration: Favorite then Unfavorite via commands
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void FavoriteThenUnfavorite_ViaCommands_LocationNotInFavorites()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Vancouver", Latitude = 49.3, Longitude = -123.1 };
+
+        new FavoriteLocationCommand(location, manager).Invoke();
+        new UnfavoriteLocationCommand(location, manager).Invoke();
+
+        Assert.IsFalse(manager.IsFavorite(location));
+        Assert.AreEqual(0, manager.GetFavorites().Count);
+    }
+}

--- a/WeatherExtension.Tests/FavoritesManagerTests.cs
+++ b/WeatherExtension.Tests/FavoritesManagerTests.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class FavoritesManagerTests
+{
+    private string _tempFilePath = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"weather-test-favorites-{Guid.NewGuid()}.json");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Favorite() — add
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void Favorite_AddsLocationToGetFavorites()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+            Admin1 = "Washington",
+            Country = "United States",
+        };
+
+        manager.Favorite(location);
+
+        var favorites = manager.GetFavorites();
+        Assert.AreEqual(1, favorites.Count);
+        Assert.AreEqual("Seattle", favorites[0].Name);
+        Assert.AreEqual(47.6, favorites[0].Latitude);
+        Assert.AreEqual(-122.3, favorites[0].Longitude);
+    }
+
+    [TestMethod]
+    public void Favorite_SameLocationTwice_DoesNotDuplicate()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+        };
+
+        manager.Favorite(location);
+        manager.Favorite(location);
+
+        Assert.AreEqual(1, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Favorite_LocationWithinThreshold_DoesNotDuplicate()
+    {
+        // Two locations within 0.01 lat/lon of each other should be treated as duplicates
+        var manager = new FavoritesManager(_tempFilePath);
+        var location1 = new GeocodingResult { Name = "Seattle", Latitude = 47.6000, Longitude = -122.3000 };
+        var location2 = new GeocodingResult { Name = "Seattle", Latitude = 47.6005, Longitude = -122.3005 };
+
+        manager.Favorite(location1);
+        manager.Favorite(location2);
+
+        Assert.AreEqual(1, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Favorite_LocationOutsideThreshold_AddsBoth()
+    {
+        // Two locations more than 0.01 apart should both be stored
+        var manager = new FavoritesManager(_tempFilePath);
+        var location1 = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var location2 = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+
+        manager.Favorite(location1);
+        manager.Favorite(location2);
+
+        Assert.AreEqual(2, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Favorite_PersistsToFile()
+    {
+        var location = new GeocodingResult
+        {
+            Name = "Portland",
+            Latitude = 45.5152,
+            Longitude = -122.6784,
+            Admin1 = "Oregon",
+            Country = "United States",
+        };
+
+        var manager1 = new FavoritesManager(_tempFilePath);
+        manager1.Favorite(location);
+
+        var manager2 = new FavoritesManager(_tempFilePath);
+        var favorites = manager2.GetFavorites();
+
+        Assert.AreEqual(1, favorites.Count);
+        Assert.AreEqual("Portland", favorites[0].Name);
+        Assert.AreEqual(45.5152, favorites[0].Latitude);
+        Assert.AreEqual(-122.6784, favorites[0].Longitude);
+    }
+
+    // ---------------------------------------------------------------
+    // Unfavorite() — remove
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void Unfavorite_RemovesLocationFromGetFavorites()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+        };
+
+        manager.Favorite(location);
+        manager.Unfavorite(location);
+
+        Assert.AreEqual(0, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Unfavorite_NonFavoritedLocation_IsNoOp()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+        };
+
+        // Should not throw
+        manager.Unfavorite(location);
+
+        Assert.AreEqual(0, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Unfavorite_PersistsRemovalToFile()
+    {
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        var manager1 = new FavoritesManager(_tempFilePath);
+        manager1.Favorite(location);
+        manager1.Unfavorite(location);
+
+        var manager2 = new FavoritesManager(_tempFilePath);
+        Assert.AreEqual(0, manager2.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Unfavorite_OnlyRemovesMatchingLocation()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var seattle = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var portland = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+
+        manager.Favorite(seattle);
+        manager.Favorite(portland);
+        manager.Unfavorite(seattle);
+
+        var favorites = manager.GetFavorites();
+        Assert.AreEqual(1, favorites.Count);
+        Assert.AreEqual("Portland", favorites[0].Name);
+    }
+
+    // ---------------------------------------------------------------
+    // IsFavorite()
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void IsFavorite_ReturnsTrueForFavoritedLocation()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.Favorite(location);
+
+        Assert.IsTrue(manager.IsFavorite(location));
+    }
+
+    [TestMethod]
+    public void IsFavorite_ReturnsFalseForUnfavoritedLocation()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        Assert.IsFalse(manager.IsFavorite(location));
+    }
+
+    [TestMethod]
+    public void IsFavorite_ReturnsFalseAfterUnfavorite()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.Favorite(location);
+        manager.Unfavorite(location);
+
+        Assert.IsFalse(manager.IsFavorite(location));
+    }
+
+    // ---------------------------------------------------------------
+    // GetFavorites()
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void GetFavorites_WithNoFavorites_ReturnsEmpty()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+
+        var favorites = manager.GetFavorites();
+
+        Assert.IsNotNull(favorites);
+        Assert.AreEqual(0, favorites.Count);
+    }
+
+    [TestMethod]
+    public void GetFavorites_ReturnsAllFavoritedLocations()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        manager.Favorite(new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 });
+        manager.Favorite(new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 });
+        manager.Favorite(new GeocodingResult { Name = "Vancouver", Latitude = 49.3, Longitude = -123.1 });
+
+        Assert.AreEqual(3, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void GetFavorites_ReturnsCopy_NotLiveReference()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        manager.Favorite(new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 });
+
+        var snapshot = manager.GetFavorites();
+        manager.Favorite(new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 });
+
+        // snapshot should still have count 1 — GetFavorites returns a copy
+        Assert.AreEqual(1, snapshot.Count);
+    }
+
+    // ---------------------------------------------------------------
+    // FavoritesChanged event
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void FavoritesChanged_FiresOnFavorite()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var eventFired = false;
+        manager.FavoritesChanged += (_, _) => eventFired = true;
+
+        manager.Favorite(location);
+
+        Assert.IsTrue(eventFired, "FavoritesChanged should fire when a location is favorited");
+    }
+
+    [TestMethod]
+    public void FavoritesChanged_FiresOnUnfavorite()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        manager.Favorite(location);
+
+        var eventFired = false;
+        manager.FavoritesChanged += (_, _) => eventFired = true;
+
+        manager.Unfavorite(location);
+
+        Assert.IsTrue(eventFired, "FavoritesChanged should fire when a location is unfavorited");
+    }
+
+    [TestMethod]
+    public void FavoritesChanged_DoesNotFireOnDuplicateFavorite()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        manager.Favorite(location);
+
+        var eventFired = false;
+        manager.FavoritesChanged += (_, _) => eventFired = true;
+
+        manager.Favorite(location); // duplicate — should be no-op
+
+        Assert.IsFalse(eventFired, "FavoritesChanged should NOT fire when favoriting a duplicate location");
+    }
+
+    [TestMethod]
+    public void FavoritesChanged_DoesNotFireOnUnfavoriteNonExistent()
+    {
+        var manager = new FavoritesManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        var eventFired = false;
+        manager.FavoritesChanged += (_, _) => eventFired = true;
+
+        manager.Unfavorite(location); // not in list — should be no-op
+
+        Assert.IsFalse(eventFired, "FavoritesChanged should NOT fire when unfavoriting a location that isn't in the list");
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor / persistence
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void Constructor_WithMissingFile_StartsEmpty()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"weather-test-no-file-{Guid.NewGuid()}.json");
+
+        var manager = new FavoritesManager(nonExistentPath);
+
+        Assert.AreEqual(0, manager.GetFavorites().Count);
+    }
+
+    [TestMethod]
+    public void Constructor_LoadsExistingDataFromFile()
+    {
+        var location = new GeocodingResult
+        {
+            Name = "Vancouver",
+            Latitude = 49.3,
+            Longitude = -123.1,
+            Admin1 = "British Columbia",
+            Country = "Canada",
+        };
+
+        var manager1 = new FavoritesManager(_tempFilePath);
+        manager1.Favorite(location);
+
+        var manager2 = new FavoritesManager(_tempFilePath);
+
+        Assert.AreEqual(1, manager2.GetFavorites().Count);
+        Assert.AreEqual("Vancouver", manager2.GetFavorites()[0].Name);
+    }
+}

--- a/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
+++ b/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
@@ -30,14 +30,6 @@ public class WeatherSettingsManagerTests
     }
 
     [TestMethod]
-    public void DefaultLocation_WithNoSettings_ReturnsDefault()
-    {
-        var manager = new WeatherSettingsManager(_tempFilePath);
-
-        Assert.AreEqual("98101", manager.DefaultLocation);
-    }
-
-    [TestMethod]
     public void TemperatureUnit_WithNoSettings_ReturnsDefaultCelsius()
     {
         var manager = new WeatherSettingsManager(_tempFilePath);
@@ -103,15 +95,6 @@ public class WeatherSettingsManagerTests
 
         // Valid value "180" (3 hours) should be preserved
         Assert.AreEqual(180, manager.UpdateIntervalMinutes);
-    }
-
-    [TestMethod]
-    public void DefaultLocation_PropertyReturnsNonNull()
-    {
-        var manager = new WeatherSettingsManager(_tempFilePath);
-
-        Assert.IsNotNull(manager.DefaultLocation);
-        Assert.IsFalse(string.IsNullOrEmpty(manager.DefaultLocation));
     }
 
     [TestMethod]

--- a/WeatherExtension/Commands/FavoriteLocationCommand.cs
+++ b/WeatherExtension/Commands/FavoriteLocationCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class FavoriteLocationCommand : InvokableCommand
+{
+	private readonly GeocodingResult _location;
+	private readonly FavoritesManager _favoritesManager;
+
+	public FavoriteLocationCommand(GeocodingResult location, FavoritesManager favoritesManager)
+	{
+		_location = location;
+		_favoritesManager = favoritesManager;
+		Name = Resources.favorite_command_name;
+		Icon = new IconInfo("⭐");
+	}
+
+	public override string Id => "com.baldbeardedbuilder.cmdpal.weather.favorite";
+
+	public override ICommandResult Invoke()
+	{
+		_favoritesManager.Favorite(_location);
+		return CommandResult.KeepOpen();
+	}
+}

--- a/WeatherExtension/Commands/UnfavoriteLocationCommand.cs
+++ b/WeatherExtension/Commands/UnfavoriteLocationCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class UnfavoriteLocationCommand : InvokableCommand
+{
+	private readonly GeocodingResult _location;
+	private readonly FavoritesManager _favoritesManager;
+
+	public UnfavoriteLocationCommand(GeocodingResult location, FavoritesManager favoritesManager)
+	{
+		_location = location;
+		_favoritesManager = favoritesManager;
+		Name = Resources.unfavorite_command_name;
+		Icon = new IconInfo("⭐");
+	}
+
+	public override string Id => "com.baldbeardedbuilder.cmdpal.weather.unfavorite";
+
+	public override ICommandResult Invoke()
+	{
+		_favoritesManager.Unfavorite(_location);
+		return CommandResult.KeepOpen();
+	}
+}

--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -50,6 +50,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		_updateTimer.Start();
 
 		_settings.Settings.SettingsChanged += OnSettingsChanged;
+		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
 
 		// Fetch weather immediately on startup
 		_ = UpdateWeatherAsync();
@@ -154,6 +155,11 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		}
 	}
 
+	private async void OnFavoritesChanged(object? sender, EventArgs e)
+	{
+		await UpdateWeatherAsync();
+	}
+
 	private async void OnSettingsChanged(object sender, Settings args)
 	{
 		await UpdateWeatherAsync();
@@ -165,6 +171,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		{
 			_isDisposed = true;
 			_settings.Settings.SettingsChanged -= OnSettingsChanged;
+			_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
 			_updateTimer?.Stop();
 			_updateTimer?.Dispose();
 		}

--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -4,6 +4,7 @@
 
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Pages;
+using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -16,6 +17,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 	private readonly OpenMeteoService _weatherService;
 	private readonly GeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settings;
+	private readonly FavoritesManager _favoritesManager;
 	private readonly WeatherBandCard _contentPage;
 	private readonly Timer _updateTimer;
 	private bool _isDisposed;
@@ -27,12 +29,14 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 		OpenMeteoService weatherService,
 		GeocodingService geocodingService,
 		WeatherSettingsManager settings,
-		WeatherBandCard contentPage)
+		WeatherBandCard contentPage,
+		FavoritesManager favoritesManager)
 	{
 		_weatherService = weatherService ?? throw new ArgumentNullException(nameof(weatherService));
 		_geocodingService = geocodingService ?? throw new ArgumentNullException(nameof(geocodingService));
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
 		_contentPage = contentPage ?? throw new ArgumentNullException(nameof(contentPage));
+		_favoritesManager = favoritesManager ?? throw new ArgumentNullException(nameof(favoritesManager));
 
 		Command = _contentPage;
 		Icon = Icons.WeatherIcon;
@@ -60,17 +64,16 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 
 		try
 		{
-			// Get coordinates for default location
-			var locations = await _geocodingService.SearchLocationAsync(_settings.DefaultLocation);
-
-			if (locations.Count == 0)
+			// Get first favorite location
+			var favorites = _favoritesManager.GetFavorites();
+			if (favorites.Count == 0)
 			{
 				Title = "--";
-				Subtitle = Resources.location_not_found;
+				Subtitle = Resources.no_favorites_hint;
 			}
 			else
 			{
-				var location = locations[0];
+				var location = favorites[0].ToGeocodingResult();
 				var weather = await _weatherService.GetCurrentWeatherAsync(
 					location.Latitude,
 					location.Longitude,
@@ -104,7 +107,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 					}
 					else
 					{
-						Subtitle = location.Name ?? _settings.DefaultLocation;
+						Subtitle = location.DisplayName;
 					}
 				}
 				else

--- a/WeatherExtension/Pages/WeatherBandCard.cs
+++ b/WeatherExtension/Pages/WeatherBandCard.cs
@@ -16,6 +16,7 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 	private readonly OpenMeteoService _weatherService;
 	private readonly GeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settings;
+	private readonly FavoritesManager? _favoritesManager;
 	private readonly FormContent _weatherForm = new();
 	private readonly CancellationTokenSource _cts = new();
 	private readonly GeocodingResult? _fixedLocation;
@@ -24,11 +25,13 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 		OpenMeteoService weatherService,
 		GeocodingService geocodingService,
 		WeatherSettingsManager settings,
+		FavoritesManager? favoritesManager = null,
 		GeocodingResult? fixedLocation = null)
 	{
 		_weatherService = weatherService ?? throw new ArgumentNullException(nameof(weatherService));
 		_geocodingService = geocodingService ?? throw new ArgumentNullException(nameof(geocodingService));
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+		_favoritesManager = favoritesManager;
 		_fixedLocation = fixedLocation;
 
 		Id = "com.baldbeardedbuilder.cmdpal.weather.card";
@@ -56,20 +59,25 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 			{
 				location = _fixedLocation;
 			}
-			else
+			else if (_favoritesManager != null)
 			{
-				var locations = await _geocodingService.SearchLocationAsync(
-					_settings.DefaultLocation, _cts.Token);
-
-				if (locations.Count == 0)
+				var favorites = _favoritesManager.GetFavorites();
+				if (favorites.Count == 0)
 				{
 					_weatherForm.DataJson = GetErrorData(
-						Resources.location_not_found);
+						Resources.no_favorites_hint);
 					RaiseItemsChanged();
 					return;
 				}
 
-				location = locations[0];
+				location = favorites[0].ToGeocodingResult();
+			}
+			else
+			{
+				_weatherForm.DataJson = GetErrorData(
+					Resources.location_not_found);
+				RaiseItemsChanged();
+				return;
 			}
 			var weather = await _weatherService.GetCurrentWeatherAsync(
 				location.Latitude,

--- a/WeatherExtension/Pages/WeatherBandCard.cs
+++ b/WeatherExtension/Pages/WeatherBandCard.cs
@@ -43,6 +43,10 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 		_weatherForm.DataJson = GetLoadingData();
 
 		_settings.Settings.SettingsChanged += OnSettingsChanged;
+		if (_favoritesManager != null)
+		{
+			_favoritesManager.FavoritesChanged += OnFavoritesChanged;
+		}
 
 		_ = LoadWeatherDataAsync();
 	}
@@ -613,6 +617,14 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
         """;
 	}
 
+	private async void OnFavoritesChanged(object? sender, EventArgs e)
+	{
+		if (_fixedLocation == null)
+		{
+			await LoadWeatherDataAsync();
+		}
+	}
+
 	private async void OnSettingsChanged(object sender, Settings args)
 	{
 		await LoadWeatherDataAsync();
@@ -621,6 +633,10 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 	public void Dispose()
 	{
 		_settings.Settings.SettingsChanged -= OnSettingsChanged;
+		if (_favoritesManager != null)
+		{
+			_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
+		}
 		_cts?.Cancel();
 		_cts?.Dispose();
 	}

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -89,15 +89,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			EmptyContent = null;
 
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
-			var items = new List<IListItem>
-			{
-				new ListItem(new NoOpCommand())
-				{
-					Title = Resources.favorites_section_title,
-					Icon = new IconInfo("\u2B50"),
-					Section = new ListSection(Resources.favorites_section_title),
-				},
-			};
+			var items = new List<IListItem>();
 
 			foreach (var pinned in favorites)
 			{

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -312,6 +312,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		var oldCts = _searchCts;
 		_searchCts = new CancellationTokenSource();
 		oldCts.Cancel();
+		oldCts.Dispose();
 		return _searchCts.Token;
 	}
 
@@ -506,6 +507,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		_settingsManager.Settings.SettingsChanged -= OnSettingsChanged;
 		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
 		_searchCts?.Cancel();
+		_searchCts?.Dispose();
 		_cts?.Cancel();
 		_cts?.Dispose();
 	}

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -22,6 +22,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	private readonly GeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settingsManager;
 	private readonly PinnedLocationsManager _pinnedLocationsManager;
+	private readonly FavoritesManager _favoritesManager;
 	private readonly Lock _sync = new();
 	private readonly CancellationTokenSource _cts = new();
 
@@ -34,17 +35,20 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		IWeatherService weatherService,
 		GeocodingService geocodingService,
 		WeatherSettingsManager settingsManager,
-		PinnedLocationsManager pinnedLocationsManager)
+		PinnedLocationsManager pinnedLocationsManager,
+		FavoritesManager favoritesManager)
 	{
 		ArgumentNullException.ThrowIfNull(weatherService);
 		ArgumentNullException.ThrowIfNull(geocodingService);
 		ArgumentNullException.ThrowIfNull(settingsManager);
 		ArgumentNullException.ThrowIfNull(pinnedLocationsManager);
+		ArgumentNullException.ThrowIfNull(favoritesManager);
 
 		_weatherService = weatherService;
 		_geocodingService = geocodingService;
 		_settingsManager = settingsManager;
 		_pinnedLocationsManager = pinnedLocationsManager;
+		_favoritesManager = favoritesManager;
 
 		Name = "Weather";
 		Title = "Weather";
@@ -53,27 +57,80 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		PlaceholderText = Resources.search_placeholder;
 		ShowDetails = true;
 
-		LoadDefaultLocationWeather();
+		LoadFavoriteLocations();
 
 		_settingsManager.Settings.SettingsChanged += OnSettingsChanged;
+		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
 	}
 
-	private async void LoadDefaultLocationWeather(CancellationToken searchCt = default)
+	private async void LoadFavoriteLocations(CancellationToken searchCt = default)
 	{
 		try
 		{
-			var defaultLocation = _settingsManager.DefaultLocation;
-			if (string.IsNullOrWhiteSpace(defaultLocation))
+			var favorites = _favoritesManager.GetFavorites();
+			if (favorites.Count == 0)
 			{
+				lock (_sync)
+				{
+					_items = [];
+					_isLoading = false;
+				}
+
+				EmptyContent = new ListItem(new NoOpCommand())
+				{
+					Title = Resources.no_favorites_hint,
+					Icon = Icons.WeatherIcon,
+				};
+
+				RaiseItemsChanged();
 				return;
 			}
 
+			EmptyContent = null;
+
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
-			var locations = await _geocodingService.SearchLocationAsync(defaultLocation, linkedCts.Token).ConfigureAwait(false);
-			if (locations.Count > 0)
+			var items = new List<IListItem>
 			{
-				await LoadWeatherForLocation(locations[0], linkedCts.Token).ConfigureAwait(false);
+				new ListItem(new NoOpCommand())
+				{
+					Title = Resources.favorites_section_title,
+					Icon = new IconInfo("\u2B50"),
+					Section = new ListSection(Resources.favorites_section_title),
+				},
+			};
+
+			foreach (var pinned in favorites)
+			{
+				var location = pinned.ToGeocodingResult();
+				try
+				{
+					var weatherData = await _weatherService.GetCurrentWeatherAsync(
+						location.Latitude,
+						location.Longitude,
+						_settingsManager.TemperatureUnit,
+						_settingsManager.WindSpeedUnit,
+						linkedCts.Token).ConfigureAwait(false);
+
+					if (weatherData != null)
+					{
+						items.Add(CreateWeatherItem(location, weatherData));
+					}
+				}
+				catch (Exception ex) when (ex is not OperationCanceledException)
+				{
+					WeatherLogger.LogToHost(
+						MessageState.Error,
+						$"Failed to load weather for favorite {location.DisplayName}: {ex.Message}");
+				}
 			}
+
+			lock (_sync)
+			{
+				_items = items.ToArray();
+				_isLoading = false;
+			}
+
+			RaiseItemsChanged();
 		}
 		catch (OperationCanceledException)
 		{
@@ -83,7 +140,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		{
 			WeatherLogger.LogToHost(
 				MessageState.Error,
-				$"Failed to load default location weather: {ex.Message}");
+				$"Failed to load favorite locations: {ex.Message}");
 		}
 	}
 
@@ -150,7 +207,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 
 		var current = weatherData.Current;
-		var tempUnit = _settingsManager.TemperatureUnit == "celsius" ? "°C" : "°F";
+		var tempUnit = _settingsManager.TemperatureUnit == "celsius" ? "\u00B0C" : "\u00B0F";
 		var windUnit = _settingsManager.WindSpeedUnit == "mph" ? "mph" : "km/h";
 		var condition = Icons.GetWeatherDescription(current.WeatherCode);
 
@@ -173,15 +230,24 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			moreCommands.Add(new CommandContextItem(new PinToDockCommand(location, _pinnedLocationsManager)));
 		}
 
+		if (_favoritesManager.IsFavorite(location))
+		{
+			moreCommands.Add(new CommandContextItem(new UnfavoriteLocationCommand(location, _favoritesManager)));
+		}
+		else
+		{
+			moreCommands.Add(new CommandContextItem(new FavoriteLocationCommand(location, _favoritesManager)));
+		}
+
 		var item = new ListItem(detailPage)
 		{
 			Title = location.DisplayName,
-			Subtitle = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
+			Subtitle = $"{condition} \u2014 {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
 			Icon = Icons.GetIconForWeatherCode(current.WeatherCode),
 			Details = new Details
 			{
 				Title = location.DisplayName,
-				Body = $"{condition} — {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
+				Body = $"{condition} \u2014 {current.Temperature:F0}{tempUnit} (feels like {current.ApparentTemperature:F0}{tempUnit})",
 				Metadata =
 				[
 					new DetailsElement { Key = "Humidity", Data = new DetailsLink($"{current.RelativeHumidity}%") },
@@ -208,7 +274,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		{
 			var ct = ResetSearchToken();
 			_lastSearchQuery = string.Empty;
-			LoadDefaultLocationWeather(ct);
+			LoadFavoriteLocations(ct);
 			return;
 		}
 
@@ -245,9 +311,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	{
 		var oldCts = _searchCts;
 		_searchCts = new CancellationTokenSource();
-		// Cancel but do not dispose immediately: the fire-and-forget debounced task may still be
-		// executing callbacks on oldCts.Token, and disposing it while those callbacks are in flight
-		// would throw ObjectDisposedException.  The GC will reclaim it once no references remain.
 		oldCts.Cancel();
 		return _searchCts.Token;
 	}
@@ -262,7 +325,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 		catch (OperationCanceledException)
 		{
-			// Expected when the debounce is cancelled by a newer search or page is disposed
 		}
 	}
 
@@ -279,8 +341,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 			var locations = await _geocodingService.SearchLocationAsync(query, ct).ConfigureAwait(false);
 
-			// Re-check cancellation after the async call returns so that stale results
-			// from an earlier query are never shown when the user has already typed more.
 			if (ct.IsCancellationRequested)
 			{
 				lock (_sync)
@@ -333,7 +393,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 				}
 			}
 
-			// Final cancellation check before committing results to the UI.
 			if (ct.IsCancellationRequested)
 			{
 				lock (_sync)
@@ -355,7 +414,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 		catch (OperationCanceledException)
 		{
-			// Expected when the search is cancelled by a newer query or page is disposed
 			lock (_sync)
 			{
 				_isLoading = false;
@@ -401,6 +459,15 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		RefreshWeather();
 	}
 
+	private void OnFavoritesChanged(object? sender, EventArgs e)
+	{
+		if (string.IsNullOrWhiteSpace(_lastSearchQuery))
+		{
+			var ct = ResetSearchToken();
+			LoadFavoriteLocations(ct);
+		}
+	}
+
 	public void RefreshWeather()
 	{
 		var ct = ResetSearchToken();
@@ -410,7 +477,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 		else
 		{
-			LoadDefaultLocationWeather(ct);
+			LoadFavoriteLocations(ct);
 		}
 	}
 
@@ -437,10 +504,9 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	public void Dispose()
 	{
 		_settingsManager.Settings.SettingsChanged -= OnSettingsChanged;
+		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
 		_searchCts?.Cancel();
-		_searchCts?.Dispose();
 		_cts?.Cancel();
 		_cts?.Dispose();
-		GC.SuppressFinalize(this);
 	}
 }

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -79,33 +79,6 @@ namespace Microsoft.CmdPal.Ext.Weather {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Postal code or city, state, country for the default weather location.
-        /// </summary>
-        public static string default_location_description {
-            get {
-                return ResourceManager.GetString("default_location_description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to city, state, country (e.g. Nashville, TN, US).
-        /// </summary>
-        public static string default_location_placeholder {
-            get {
-                return ResourceManager.GetString("default_location_placeholder", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Default Location.
-        /// </summary>
-        public static string default_location_title {
-            get {
-                return ResourceManager.GetString("default_location_title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Weather.
         /// </summary>
         public static string dockband_title {
@@ -473,5 +446,42 @@ namespace Microsoft.CmdPal.Ext.Weather {
                 return ResourceManager.GetString("wind_speed_unit_title", resourceCulture);
             }
         }
+    
+        /// <summary>
+        ///   Looks up a localized string similar to Favorites.
+        /// </summary>
+        internal static string favorites_section_title {
+            get {
+                return ResourceManager.GetString("favorites_section_title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add to Favorites.
+        /// </summary>
+        internal static string favorite_command_name {
+            get {
+                return ResourceManager.GetString("favorite_command_name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove from Favorites.
+        /// </summary>
+        internal static string unfavorite_command_name {
+            get {
+                return ResourceManager.GetString("unfavorite_command_name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Search for a location and add it to your favorites.
+        /// </summary>
+        internal static string no_favorites_hint {
+            get {
+                return ResourceManager.GetString("no_favorites_hint", resourceCulture);
+            }
+        }
+
     }
 }

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -450,7 +450,7 @@ namespace Microsoft.CmdPal.Ext.Weather {
         /// <summary>
         ///   Looks up a localized string similar to Favorites.
         /// </summary>
-        internal static string favorites_section_title {
+        public static string favorites_section_title {
             get {
                 return ResourceManager.GetString("favorites_section_title", resourceCulture);
             }
@@ -459,7 +459,7 @@ namespace Microsoft.CmdPal.Ext.Weather {
         /// <summary>
         ///   Looks up a localized string similar to Add to Favorites.
         /// </summary>
-        internal static string favorite_command_name {
+        public static string favorite_command_name {
             get {
                 return ResourceManager.GetString("favorite_command_name", resourceCulture);
             }
@@ -468,7 +468,7 @@ namespace Microsoft.CmdPal.Ext.Weather {
         /// <summary>
         ///   Looks up a localized string similar to Remove from Favorites.
         /// </summary>
-        internal static string unfavorite_command_name {
+        public static string unfavorite_command_name {
             get {
                 return ResourceManager.GetString("unfavorite_command_name", resourceCulture);
             }
@@ -477,7 +477,7 @@ namespace Microsoft.CmdPal.Ext.Weather {
         /// <summary>
         ///   Looks up a localized string similar to Search for a location and add it to your favorites.
         /// </summary>
-        internal static string no_favorites_hint {
+        public static string no_favorites_hint {
             get {
                 return ResourceManager.GetString("no_favorites_hint", resourceCulture);
             }

--- a/WeatherExtension/Properties/Resources.resx
+++ b/WeatherExtension/Properties/Resources.resx
@@ -199,15 +199,6 @@
   <data name="location_not_found" xml:space="preserve">
     <value>Location not found</value>
   </data>
-  <data name="default_location_title" xml:space="preserve">
-    <value>Default Location</value>
-  </data>
-  <data name="default_location_description" xml:space="preserve">
-    <value>Postal code or city, state, country for the default weather location</value>
-  </data>
-  <data name="default_location_placeholder" xml:space="preserve">
-    <value>city, state, country (e.g. Nashville, TN, US)</value>
-  </data>
   <data name="temperature_unit_title" xml:space="preserve">
     <value>Temperature Unit</value>
   </data>
@@ -255,5 +246,17 @@
   </data>
   <data name="twelve_hours" xml:space="preserve">
     <value>12 hours</value>
+  </data>
+  <data name="favorites_section_title" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="favorite_command_name" xml:space="preserve">
+    <value>Add to Favorites</value>
+  </data>
+  <data name="unfavorite_command_name" xml:space="preserve">
+    <value>Remove from Favorites</value>
+  </data>
+  <data name="no_favorites_hint" xml:space="preserve">
+    <value>Search for a location and add it to your favorites</value>
   </data>
 </root>

--- a/WeatherExtension/Services/FavoritesManager.cs
+++ b/WeatherExtension/Services/FavoritesManager.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CommandPalette.Extensions;
+using System.Text.Json;
+
+namespace Microsoft.CmdPal.Ext.Weather.Services;
+
+public sealed class FavoritesManager
+{
+	private readonly string _filePath;
+	private List<PinnedLocation> _favoriteLocations = [];
+	private readonly Lock _sync = new();
+
+	public event EventHandler? FavoritesChanged;
+
+	public FavoritesManager()
+	{
+		var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		var directory = Path.Combine(localAppData, "Microsoft.CmdPal");
+		Directory.CreateDirectory(directory);
+		_filePath = Path.Combine(directory, "favorite-weather-locations.json");
+		LoadFromFile();
+	}
+
+	internal FavoritesManager(string filePath)
+	{
+		_filePath = filePath;
+		LoadFromFile();
+	}
+
+	public void Favorite(GeocodingResult location)
+	{
+		lock (_sync)
+		{
+			if (_favoriteLocations.Any(p => Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+										    Math.Abs(p.Longitude - location.Longitude) < 0.01))
+			{
+				return;
+			}
+
+			_favoriteLocations.Add(new PinnedLocation
+			{
+				Latitude = location.Latitude,
+				Longitude = location.Longitude,
+				DisplayName = location.DisplayName,
+				Name = location.Name,
+				Admin1 = location.Admin1,
+				Country = location.Country,
+			});
+
+			SaveToFile();
+		}
+
+		FavoritesChanged?.Invoke(this, EventArgs.Empty);
+	}
+
+	public void Unfavorite(GeocodingResult location)
+	{
+		bool removed;
+		lock (_sync)
+		{
+			var toRemove = _favoriteLocations.FirstOrDefault(p =>
+				Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+				Math.Abs(p.Longitude - location.Longitude) < 0.01);
+
+			removed = toRemove != null && _favoriteLocations.Remove(toRemove);
+
+			if (removed)
+			{
+				SaveToFile();
+			}
+		}
+
+		if (removed)
+		{
+			FavoritesChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	public bool IsFavorite(GeocodingResult location)
+	{
+		lock (_sync)
+		{
+			return _favoriteLocations.Any(p =>
+				Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+				Math.Abs(p.Longitude - location.Longitude) < 0.01);
+		}
+	}
+
+	public List<PinnedLocation> GetFavorites()
+	{
+		lock (_sync)
+		{
+			return new List<PinnedLocation>(_favoriteLocations);
+		}
+	}
+
+	private void LoadFromFile()
+	{
+		try
+		{
+			if (File.Exists(_filePath))
+			{
+				var json = File.ReadAllText(_filePath);
+				var locations = JsonSerializer.Deserialize<List<PinnedLocation>>(json, WeatherJsonContext.Default.ListPinnedLocation);
+				if (locations != null)
+				{
+					_favoriteLocations = locations;
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Error,
+				$"Failed to load favorite locations: {ex.Message}");
+		}
+	}
+
+	private void SaveToFile()
+	{
+		try
+		{
+			var json = JsonSerializer.Serialize(_favoriteLocations, WeatherJsonContext.Default.ListPinnedLocation);
+			File.WriteAllText(_filePath, json);
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Error,
+				$"Failed to save favorite locations: {ex.Message}");
+		}
+	}
+}

--- a/WeatherExtension/Services/WeatherSettingsManager.cs
+++ b/WeatherExtension/Services/WeatherSettingsManager.cs
@@ -14,15 +14,6 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
 
     private static string Namespaced(string propertyName) => $"{Namespace}.{propertyName}";
 
-    private readonly TextSetting _defaultLocation = new(
-        Namespaced(nameof(DefaultLocation)),
-        Resources.default_location_title,
-        Resources.default_location_description,
-        "98101")
-    {
-        Placeholder = Resources.default_location_placeholder,
-    };
-
     private readonly ChoiceSetSetting _temperatureUnit = new(
         Namespaced(nameof(TemperatureUnit)),
         Resources.temperature_unit_title,
@@ -60,8 +51,6 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
 
     private static readonly HashSet<string> _validIntervals = ["60", "180", "360", "720"];
 
-    public string DefaultLocation => _defaultLocation.Value ?? "98101";
-
     public string TemperatureUnit => _temperatureUnit.Value ?? "celsius";
 
     public string WindSpeedUnit => _windSpeedUnit.Value ?? "kmh";
@@ -74,7 +63,6 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
     {
         FilePath = SettingsJsonPath();
 
-        Settings.Add(_defaultLocation);
         Settings.Add(_temperatureUnit);
         Settings.Add(_windSpeedUnit);
         Settings.Add(_showForecast);
@@ -90,7 +78,6 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
     {
         FilePath = filePath;
 
-        Settings.Add(_defaultLocation);
         Settings.Add(_temperatureUnit);
         Settings.Add(_windSpeedUnit);
         Settings.Add(_showForecast);

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -16,6 +16,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	private readonly OpenMeteoService _weatherService = new();
 	private readonly GeocodingService _geocodingService = new();
 	private readonly PinnedLocationsManager _pinnedLocationsManager = new();
+	private readonly FavoritesManager _favoritesManager = new();
 	private readonly WeatherBandCard _weatherContentPage;
 	private readonly CurrentWeatherBand _currentWeatherBand;
 	private readonly WeatherListPage _weatherPage;
@@ -29,11 +30,11 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		Icon = Icons.WeatherIcon;
 		Settings = _settingsManager.Settings;
 
-		_weatherContentPage = new WeatherBandCard(_weatherService, _geocodingService, _settingsManager);
-		_currentWeatherBand = new CurrentWeatherBand(_weatherService, _geocodingService, _settingsManager, _weatherContentPage);
+		_weatherContentPage = new WeatherBandCard(_weatherService, _geocodingService, _settingsManager, _favoritesManager);
+		_currentWeatherBand = new CurrentWeatherBand(_weatherService, _geocodingService, _settingsManager, _weatherContentPage, _favoritesManager);
 
 		// Create main weather page
-		_weatherPage = new WeatherListPage(_weatherService, _geocodingService, _settingsManager, _pinnedLocationsManager);
+		_weatherPage = new WeatherListPage(_weatherService, _geocodingService, _settingsManager, _pinnedLocationsManager, _favoritesManager);
 
 		_topLevelItems =
 		[
@@ -46,6 +47,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		];
 
 		_pinnedLocationsManager.PinnedLocationsChanged += OnPinnedLocationsChanged;
+		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
 	}
 
 	public override ICommandItem[] TopLevelCommands() => _topLevelItems;
@@ -68,7 +70,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		foreach (var pinnedLocation in pinnedLocations)
 		{
 			var location = pinnedLocation.ToGeocodingResult();
-			var bandCard = new WeatherBandCard(_weatherService, _geocodingService, _settingsManager, location);
+			var bandCard = new WeatherBandCard(_weatherService, _geocodingService, _settingsManager, _favoritesManager, location);
 			var pinnedBand = new PinnedWeatherBand(location, _weatherService, _settingsManager, bandCard);
 			_pinnedBands.Add(pinnedBand);
 
@@ -86,6 +88,11 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		return dockItems.ToArray();
 	}
 
+	private void OnFavoritesChanged(object? sender, EventArgs e)
+	{
+		// Favorites change is handled by WeatherListPage directly
+	}
+
 	private void OnPinnedLocationsChanged(object? sender, EventArgs e)
 	{
 		foreach (var band in _pinnedBands)
@@ -99,6 +106,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	public override void Dispose()
 	{
 		_pinnedLocationsManager.PinnedLocationsChanged -= OnPinnedLocationsChanged;
+		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
 		foreach (var band in _pinnedBands)
 		{
 			band.Dispose();

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -47,7 +47,6 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		];
 
 		_pinnedLocationsManager.PinnedLocationsChanged += OnPinnedLocationsChanged;
-		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
 	}
 
 	public override ICommandItem[] TopLevelCommands() => _topLevelItems;
@@ -88,11 +87,6 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		return dockItems.ToArray();
 	}
 
-	private void OnFavoritesChanged(object? sender, EventArgs e)
-	{
-		// Favorites change is handled by WeatherListPage directly
-	}
-
 	private void OnPinnedLocationsChanged(object? sender, EventArgs e)
 	{
 		foreach (var band in _pinnedBands)
@@ -106,7 +100,6 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	public override void Dispose()
 	{
 		_pinnedLocationsManager.PinnedLocationsChanged -= OnPinnedLocationsChanged;
-		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
 		foreach (var band in _pinnedBands)
 		{
 			band.Dispose();


### PR DESCRIPTION
## Summary
Replaces the "default location" setting with a favorites system per issue #61.

### Changes
- **FavoritesManager service** — JSON file persistence (`favorite-weather-locations.json`), mirrors PinnedLocationsManager pattern with Favorite/Unfavorite/IsFavorite/GetFavorites API
- **Favorite/Unfavorite commands** — context menu items on location results (⭐ icon)
- **WeatherListPage** — home screen shows favorited locations with weather data; search hides favorites, clearing search restores them
- **DockBands** — CurrentWeatherBand and WeatherBandCard use first favorite instead of removed DefaultLocation setting
- **Settings** — removed DefaultLocation from WeatherSettingsManager
- **Resources** — added 4 favorites strings, removed 3 default_location strings
- **Tests** — 20 FavoritesManager tests + 9 FavoriteCommand tests, removed obsolete DefaultLocation assertions

### Not yet implemented
- **Migration**: auto-migrating existing DefaultLocation to favorites on upgrade (needs research on reading old settings JSON before it's cleared — may need follow-up issue)

Closes #61