### PR TITLE
feat: migrate legacy DefaultLocation setting to favorites on first run

### DIFF
--- a/WeatherExtension.Tests/DefaultLocationMigrationTests.cs
+++ b/WeatherExtension.Tests/DefaultLocationMigrationTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class DefaultLocationMigrationTests
+{
+	private string? _tempFile;
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		if (_tempFile != null && File.Exists(_tempFile))
+		{
+			File.Delete(_tempFile);
+		}
+	}
+
+	[TestMethod]
+	public async Task MigrateDefaultLocationAsync_WithCustomLocation_ReturnsValueAndRemovesKey()
+	{
+		_tempFile = Path.GetTempFileName();
+		await File.WriteAllTextAsync(_tempFile,
+			"""{"weather.DefaultLocation": "Seattle, WA", "weather.TemperatureUnit": "celsius"}""");
+
+		var result = await WeatherSettingsManager.MigrateDefaultLocationAsync(_tempFile);
+
+		Assert.AreEqual("Seattle, WA", result, "Expected the custom location to be returned");
+
+		var json = await File.ReadAllTextAsync(_tempFile);
+		var obj = JsonNode.Parse(json)?.AsObject();
+		Assert.IsNotNull(obj);
+		Assert.IsFalse(obj.ContainsKey("weather.DefaultLocation"), "Key should have been removed after migration");
+		Assert.IsTrue(obj.ContainsKey("weather.TemperatureUnit"), "Unrelated keys should be preserved");
+	}
+
+	[TestMethod]
+	public async Task MigrateDefaultLocationAsync_WithDefaultValue_ReturnsNull()
+	{
+		_tempFile = Path.GetTempFileName();
+		await File.WriteAllTextAsync(_tempFile,
+			"""{"weather.DefaultLocation": "98101"}""");
+
+		var result = await WeatherSettingsManager.MigrateDefaultLocationAsync(_tempFile);
+
+		Assert.IsNull(result, "Default value '98101' should not trigger migration");
+
+		var json = await File.ReadAllTextAsync(_tempFile);
+		var obj = JsonNode.Parse(json)?.AsObject();
+		Assert.IsNotNull(obj);
+		Assert.IsTrue(obj.ContainsKey("weather.DefaultLocation"), "Key should be unchanged when value is the default");
+	}
+
+	[TestMethod]
+	public async Task MigrateDefaultLocationAsync_NoKey_ReturnsNull()
+	{
+		_tempFile = Path.GetTempFileName();
+		await File.WriteAllTextAsync(_tempFile,
+			"""{"weather.TemperatureUnit": "fahrenheit"}""");
+
+		var result = await WeatherSettingsManager.MigrateDefaultLocationAsync(_tempFile);
+
+		Assert.IsNull(result, "Missing key should return null");
+	}
+
+	[TestMethod]
+	public async Task MigrateDefaultLocationAsync_FileNotFound_ReturnsNull()
+	{
+		var nonExistentPath = Path.Combine(Path.GetTempPath(), "does-not-exist-" + Path.GetRandomFileName() + ".json");
+
+		var result = await WeatherSettingsManager.MigrateDefaultLocationAsync(nonExistentPath);
+
+		Assert.IsNull(result, "Non-existent file should return null without throwing");
+	}
+
+	[TestMethod]
+	public async Task MigrateDefaultLocationAsync_Idempotent_SecondCallReturnsNull()
+	{
+		_tempFile = Path.GetTempFileName();
+		await File.WriteAllTextAsync(_tempFile,
+			"""{"weather.DefaultLocation": "Paris, France"}""");
+
+		var firstResult = await WeatherSettingsManager.MigrateDefaultLocationAsync(_tempFile);
+		var secondResult = await WeatherSettingsManager.MigrateDefaultLocationAsync(_tempFile);
+
+		Assert.AreEqual("Paris, France", firstResult, "First call should return the location");
+		Assert.IsNull(secondResult, "Second call should return null - key was removed on first run");
+	}
+}

--- a/WeatherExtension/Services/WeatherSettingsManager.cs
+++ b/WeatherExtension/Services/WeatherSettingsManager.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using BaldBeardedBuilder.WeatherExtension;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
 

--- a/WeatherExtension/Services/WeatherSettingsManager.cs
+++ b/WeatherExtension/Services/WeatherSettingsManager.cs
@@ -4,6 +4,9 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
@@ -99,12 +102,60 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
         }
     }
 
-    private static string SettingsJsonPath()
+    internal static string SettingsJsonPath()
     {
         // Standalone implementation - use LocalApplicationData for settings
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var directory = Path.Combine(localAppData, "Microsoft.CmdPal");
         Directory.CreateDirectory(directory);
         return Path.Combine(directory, "settings.json");
+    }
+
+    /// <summary>
+    /// Reads the settings file and returns the old DefaultLocation value if it was
+    /// set by the user (i.e. differs from the default "98101"). Also removes the key
+    /// from the file so the migration only runs once. Returns null when no migration
+    /// is needed or the file cannot be read.
+    /// </summary>
+    internal static async Task<string?> MigrateDefaultLocationAsync(string settingsFilePath)
+    {
+        const string key = "weather.DefaultLocation";
+        const string defaultValue = "98101";
+
+        try
+        {
+            if (!File.Exists(settingsFilePath))
+            {
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(settingsFilePath).ConfigureAwait(false);
+            var node = JsonNode.Parse(json);
+            if (node is not JsonObject obj || !obj.ContainsKey(key))
+            {
+                return null;
+            }
+
+            var value = obj[key]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(value) || value == defaultValue)
+            {
+                return null;
+            }
+
+            // Remove the key so migration only runs once
+            obj.Remove(key);
+
+            var updated = obj.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(settingsFilePath, updated).ConfigureAwait(false);
+
+            return value;
+        }
+        catch (Exception ex)
+        {
+            WeatherLogger.LogToHost(
+                Microsoft.CommandPalette.Extensions.MessageState.Error,
+                $"DefaultLocation migration error: {ex.Message}");
+            return null;
+        }
     }
 }

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using System.Threading;
 using System.Threading.Tasks;
+using BaldBeardedBuilder.WeatherExtension;
 
 namespace Microsoft.CmdPal.Ext.Weather;
 

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -131,7 +131,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 			{
 				WeatherLogger.LogToHost(
 					Microsoft.CommandPalette.Extensions.MessageState.Warning,
-					$"DefaultLocation migration: geocoding returned no results for "{oldLocation}"");
+					$"DefaultLocation migration: geocoding returned no results for \"{oldLocation}\"");
 				return;
 			}
 
@@ -139,7 +139,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 
 			WeatherLogger.LogToHost(
 				Microsoft.CommandPalette.Extensions.MessageState.Info,
-				$"DefaultLocation migration complete: "{oldLocation}" added to favorites as "{results[0].DisplayName}"");
+				$"DefaultLocation migration complete: \"{oldLocation}\" added to favorites as \"{results[0].DisplayName}\"");
 		}
 		catch (Exception ex)
 		{

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -7,6 +7,8 @@ using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.CmdPal.Ext.Weather;
 
@@ -22,6 +24,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	private readonly WeatherListPage _weatherPage;
 	private readonly ICommandItem[] _topLevelItems;
 	private List<PinnedWeatherBand> _pinnedBands = [];
+	private bool _migrationCompleted;
 
 	public WeatherCommandsProvider()
 	{
@@ -47,6 +50,9 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		];
 
 		_pinnedLocationsManager.PinnedLocationsChanged += OnPinnedLocationsChanged;
+
+		// Fire-and-forget migration: runs once to move old DefaultLocation into favorites
+		_ = Task.Run(() => RunDefaultLocationMigrationAsync());
 	}
 
 	public override ICommandItem[] TopLevelCommands() => _topLevelItems;
@@ -96,6 +102,52 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		_pinnedBands.Clear();
 	}
 
+
+	private async Task RunDefaultLocationMigrationAsync()
+	{
+		if (_migrationCompleted)
+		{
+			return;
+		}
+
+		_migrationCompleted = true;
+
+		try
+		{
+			var settingsPath = WeatherSettingsManager.SettingsJsonPath();
+			var oldLocation = await WeatherSettingsManager.MigrateDefaultLocationAsync(settingsPath).ConfigureAwait(false);
+
+			if (oldLocation == null)
+			{
+				return;
+			}
+
+			WeatherLogger.LogToHost(
+				Microsoft.CommandPalette.Extensions.MessageState.Info,
+				$"Migrating DefaultLocation to favorites: {oldLocation}");
+
+			var results = await _geocodingService.SearchLocationAsync(oldLocation, CancellationToken.None).ConfigureAwait(false);
+			if (results.Count == 0)
+			{
+				WeatherLogger.LogToHost(
+					Microsoft.CommandPalette.Extensions.MessageState.Warning,
+					$"DefaultLocation migration: geocoding returned no results for "{oldLocation}"");
+				return;
+			}
+
+			_favoritesManager.Favorite(results[0]);
+
+			WeatherLogger.LogToHost(
+				Microsoft.CommandPalette.Extensions.MessageState.Info,
+				$"DefaultLocation migration complete: "{oldLocation}" added to favorites as "{results[0].DisplayName}"");
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				Microsoft.CommandPalette.Extensions.MessageState.Error,
+				$"DefaultLocation migration failed: {ex.Message}");
+		}
+	}
 
 	public override void Dispose()
 	{


### PR DESCRIPTION
Implements issue #68 — auto-migrates the legacy `weather.DefaultLocation` setting to a favorite when a user launches after updating.

## Changes
- `WeatherSettingsManager.MigrateDefaultLocationAsync` — reads settings JSON, removes the key if value is non-default, returns the location string
- `WeatherCommandsProvider.RunDefaultLocationMigrationAsync` — fire-and-forget from constructor; geocodes the returned value and calls `_favoritesManager.Favorite()`

## Tests added (`DefaultLocationMigrationTests.cs`, 5 tests)
- `WithCustomLocation_ReturnsValueAndRemovesKey` — verifies key removal and value return
- `WithDefaultValue_ReturnsNull` — "98101" is skipped (old default, nothing to migrate)
- `NoKey_ReturnsNull` — missing key returns null cleanly
- `FileNotFound_ReturnsNull` — no exception on missing file
- `Idempotent_SecondCallReturnsNull` — key removed on first call; second call returns null

Closes #68