### PR TITLE
feat: trigger release workflow on tag push instead of GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release to Microsoft Store
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -31,7 +32,7 @@ jobs:
         id: version
         shell: pwsh
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = "${{ github.ref_name }}"
           $version = $tag -replace '^v', ''
           
           # Ensure 4-part version (X.Y.Z.0)
@@ -208,6 +209,11 @@ jobs:
           path: WeatherExtension/**/*.msix
           retention-days: 7
 
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"
+
       - name: Upload MSIX packages to GitHub Release
         shell: pwsh
         env:
@@ -217,7 +223,7 @@ jobs:
           
           foreach ($file in $msixFiles) {
             Write-Host "Uploading $($file.Name) to release..."
-            gh release upload "${{ github.event.release.tag_name }}" "$($file.FullName)" --clobber
+            gh release upload "${{ github.ref_name }}" "$($file.FullName)" --clobber
           }
 
       # --- Build Store-specific packages with the MS Store publisher identity ---


### PR DESCRIPTION
## Summary

Refactors the release workflow to trigger on tag push (`v*`) instead of requiring a manually-created GitHub Release.

## Changes

- **Trigger**: `on: release: types: [published]` → `on: push: tags: ['v*']`
- **Tag source**: `github.event.release.tag_name` → `github.ref_name` (2 occurrences)
- **New step**: "Create GitHub Release" added before artifact upload — uses `gh release create` with `--generate-notes`
- **No changes** to build, test, sign, MSIX publish, or Store submission steps

## Why

Eliminates the manual step of creating a GitHub Release before artifacts can be built and uploaded. Pushing a version tag is now the single trigger for the entire pipeline.

Closes #74