### PR TITLE
refactor: add GlobalUsings.cs to test project

### DIFF
--- a/WeatherExtension.Tests/ConnectivityProbeTests.cs
+++ b/WeatherExtension.Tests/ConnectivityProbeTests.cs
@@ -2,13 +2,7 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/ConvertPhotonResultsTests.cs
+++ b/WeatherExtension.Tests/ConvertPhotonResultsTests.cs
@@ -4,8 +4,6 @@
 
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/DockBandCardSyncTests.cs
+++ b/WeatherExtension.Tests/DockBandCardSyncTests.cs
@@ -2,14 +2,10 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Weather.DockBands;
 using Microsoft.CmdPal.Ext.Weather.Pages;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/EmptySearchHintPageTests.cs
+++ b/WeatherExtension.Tests/EmptySearchHintPageTests.cs
@@ -5,7 +5,6 @@
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/FavoriteCommandTests.cs
+++ b/WeatherExtension.Tests/FavoriteCommandTests.cs
@@ -2,12 +2,10 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using Microsoft.CmdPal.Ext.Weather.Commands;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/FavoritesManagerTests.cs
+++ b/WeatherExtension.Tests/FavoritesManagerTests.cs
@@ -2,11 +2,9 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/GeocodingResultTests.cs
+++ b/WeatherExtension.Tests/GeocodingResultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Ext.Weather.Models;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/GeocodingServiceTests.cs
+++ b/WeatherExtension.Tests/GeocodingServiceTests.cs
@@ -4,13 +4,6 @@
 
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/GlobalUsings.cs
+++ b/WeatherExtension.Tests/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Net;
+global using System.Net.Http;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/WeatherExtension.Tests/HourlyForecastDataTests.cs
+++ b/WeatherExtension.Tests/HourlyForecastDataTests.cs
@@ -5,7 +5,6 @@
 using System.Text.Json;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/HourlyForecastTests.cs
+++ b/WeatherExtension.Tests/HourlyForecastTests.cs
@@ -2,18 +2,14 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/IconsTests.cs
+++ b/WeatherExtension.Tests/IconsTests.cs
@@ -2,7 +2,6 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/PinUnpinCommandTests.cs
+++ b/WeatherExtension.Tests/PinUnpinCommandTests.cs
@@ -2,12 +2,10 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using Microsoft.CmdPal.Ext.Weather.Commands;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/PinnedLocationsManagerTests.cs
+++ b/WeatherExtension.Tests/PinnedLocationsManagerTests.cs
@@ -2,11 +2,9 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/WeatherDataModelTests.cs
+++ b/WeatherExtension.Tests/WeatherDataModelTests.cs
@@ -2,11 +2,9 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/WeatherServiceInterfaceTests.cs
+++ b/WeatherExtension.Tests/WeatherServiceInterfaceTests.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
+++ b/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
@@ -2,10 +2,8 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using Microsoft.CmdPal.Ext.Weather.Services;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 


### PR DESCRIPTION
Closes #73

Adds `GlobalUsings.cs` to the test project with the 8 most commonly used namespaces across all test files. Removes the corresponding per-file `using` directives from all 16 test files.

**Globals added:**
- `System`
- `System.Collections.Generic`
- `System.Linq`
- `System.Net`
- `System.Net.Http`
- `System.Threading`
- `System.Threading.Tasks`
- `Microsoft.VisualStudio.TestTools.UnitTesting`

Net change: +8 global lines, -42 per-file using lines. All file-specific usings (System.IO, System.Reflection, model/service namespaces, etc.) are untouched.