### PR TITLE
refactor: extract IGeocodingService interface for testability

### DIFF
--- a/WeatherExtension/DockBands/CurrentWeatherBand.cs
+++ b/WeatherExtension/DockBands/CurrentWeatherBand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CmdPal.Ext.Weather.DockBands;
 internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 {
 	private readonly OpenMeteoService _weatherService;
-	private readonly GeocodingService _geocodingService;
+	private readonly IGeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settings;
 	private readonly FavoritesManager _favoritesManager;
 	private readonly WeatherBandCard _contentPage;
@@ -27,7 +27,7 @@ internal sealed partial class CurrentWeatherBand : ListItem, IDisposable
 
 	public CurrentWeatherBand(
 		OpenMeteoService weatherService,
-		GeocodingService geocodingService,
+		IGeocodingService geocodingService,
 		WeatherSettingsManager settings,
 		WeatherBandCard contentPage,
 		FavoritesManager favoritesManager)

--- a/WeatherExtension/Pages/WeatherBandCard.cs
+++ b/WeatherExtension/Pages/WeatherBandCard.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CmdPal.Ext.Weather.Pages;
 internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 {
 	private readonly OpenMeteoService _weatherService;
-	private readonly GeocodingService _geocodingService;
+	private readonly IGeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settings;
 	private readonly FavoritesManager? _favoritesManager;
 	private readonly FormContent _weatherForm = new();
@@ -23,7 +23,7 @@ internal sealed partial class WeatherBandCard : ContentPage, IDisposable
 
 	public WeatherBandCard(
 		OpenMeteoService weatherService,
-		GeocodingService geocodingService,
+		IGeocodingService geocodingService,
 		WeatherSettingsManager settings,
 		FavoritesManager? favoritesManager = null,
 		GeocodingResult? fixedLocation = null)

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -16,7 +16,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	private const int MinSearchLength = 3;
 
 	private readonly IWeatherService _weatherService;
-	private readonly GeocodingService _geocodingService;
+	private readonly IGeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settingsManager;
 	private readonly PinnedLocationsManager _pinnedLocationsManager;
 	private readonly FavoritesManager _favoritesManager;
@@ -30,7 +30,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 	public WeatherListPage(
 		IWeatherService weatherService,
-		GeocodingService geocodingService,
+		IGeocodingService geocodingService,
 		WeatherSettingsManager settingsManager,
 		PinnedLocationsManager pinnedLocationsManager,
 		FavoritesManager favoritesManager)

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
 
-public sealed partial class GeocodingService : IDisposable
+public sealed partial class GeocodingService : IGeocodingService
 {
 	private readonly HttpClient _httpClient;
 	private const string NominatimUrl = "https://nominatim.openstreetmap.org/search";

--- a/WeatherExtension/Services/IGeocodingService.cs
+++ b/WeatherExtension/Services/IGeocodingService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Ext.Weather.Models;
+using System.Threading;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
 

--- a/WeatherExtension/Services/IGeocodingService.cs
+++ b/WeatherExtension/Services/IGeocodingService.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Weather.Models;
+
+namespace Microsoft.CmdPal.Ext.Weather.Services;
+
+public interface IGeocodingService : IDisposable
+{
+    Task<List<GeocodingResult>> SearchLocationAsync(string query, CancellationToken ct = default);
+}

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -14,7 +14,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 {
 	private readonly WeatherSettingsManager _settingsManager = new();
 	private readonly OpenMeteoService _weatherService = new();
-	private readonly GeocodingService _geocodingService = new();
+	private readonly IGeocodingService _geocodingService = new GeocodingService();
 	private readonly PinnedLocationsManager _pinnedLocationsManager = new();
 	private readonly FavoritesManager _favoritesManager = new();
 	private readonly WeatherBandCard _weatherContentPage;

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -14,7 +14,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 {
 	private readonly WeatherSettingsManager _settingsManager = new();
 	private readonly OpenMeteoService _weatherService = new();
-	private readonly IGeocodingService _geocodingService = new GeocodingService();
+	private readonly GeocodingService _geocodingService = new();
 	private readonly PinnedLocationsManager _pinnedLocationsManager = new();
 	private readonly FavoritesManager _favoritesManager = new();
 	private readonly WeatherBandCard _weatherContentPage;


### PR DESCRIPTION
Extracts `IGeocodingService` interface from `GeocodingService` so consumers (WeatherListPage, WeatherBandCard, CurrentWeatherBand) depend on the abstraction rather than the concrete class. This enables unit testing of those consumers without real HTTP calls, mirroring the existing `IWeatherService` pattern.

## Changes
- New `IGeocodingService.cs` — `IDisposable` + `SearchLocationAsync`
- `GeocodingService` now implements `IGeocodingService` (was `IDisposable` directly)
- 3 consumers updated to accept `IGeocodingService` in field/constructor
- `WeatherCommandsProvider` field typed as `IGeocodingService`, initialized with `new GeocodingService()`

Closes #71