### PR TITLE
feat: add dock band subtitle setting (#84)

### DIFF
--- a/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
+++ b/WeatherExtension.Tests/WeatherSettingsManagerTests.cs
@@ -103,4 +103,12 @@ public class WeatherSettingsManagerTests
         Assert.IsNotNull(manager.TemperatureUnit);
         Assert.IsFalse(string.IsNullOrEmpty(manager.TemperatureUnit));
     }
+
+    [TestMethod]
+    public void DockBandSubtitle_DefaultsToHighLow()
+    {
+        var manager = new WeatherSettingsManager(_tempFilePath);
+
+        Assert.AreEqual("highlow", manager.DockBandSubtitle);
+    }
 }

--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -77,17 +77,24 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 					dockCommandItem.Icon = Icon;
 				}
 
-				var forecast = await _weatherService.GetForecastAsync(
-					_location.Latitude,
-					_location.Longitude,
-					_settings.TemperatureUnit);
-
-				if (forecast?.Daily?.TemperatureMax?.Count > 0 &&
-					forecast.Daily.TemperatureMin?.Count > 0)
+				if (_settings.DockBandSubtitle == "highlow")
 				{
-					var high = forecast.Daily.TemperatureMax[0];
-					var low = forecast.Daily.TemperatureMin[0];
-					Subtitle = $"{_location.DisplayName} — H: {high:F0}{unit}  L: {low:F0}{unit}";
+					var forecast = await _weatherService.GetForecastAsync(
+						_location.Latitude,
+						_location.Longitude,
+						_settings.TemperatureUnit);
+
+					if (forecast?.Daily?.TemperatureMax?.Count > 0 &&
+						forecast.Daily.TemperatureMin?.Count > 0)
+					{
+						var high = forecast.Daily.TemperatureMax[0];
+						var low = forecast.Daily.TemperatureMin[0];
+						Subtitle = $"H: {high:F0}{unit}  L: {low:F0}{unit}";
+					}
+					else
+					{
+						Subtitle = _location.DisplayName;
+					}
 				}
 				else
 				{

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -124,6 +124,42 @@ namespace Microsoft.CmdPal.Ext.Weather {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dock Band Subtitle.
+        /// </summary>
+        public static string dock_band_subtitle_title {
+            get {
+                return ResourceManager.GetString("dock_band_subtitle_title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Choose what to display in the dock band subtitle.
+        /// </summary>
+        public static string dock_band_subtitle_description {
+            get {
+                return ResourceManager.GetString("dock_band_subtitle_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location Name.
+        /// </summary>
+        public static string dock_band_subtitle_location {
+            get {
+                return ResourceManager.GetString("dock_band_subtitle_location", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to High/Low Temperatures.
+        /// </summary>
+        public static string dock_band_subtitle_highlow {
+            get {
+                return ResourceManager.GetString("dock_band_subtitle_highlow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Get current weather and forecast information.
         /// </summary>
         public static string extension_description {

--- a/WeatherExtension/Properties/Resources.resx
+++ b/WeatherExtension/Properties/Resources.resx
@@ -153,6 +153,18 @@ If you continue to have issues, please [file a bug](https://github.com/michaeljo
   <data name="current_weather" xml:space="preserve">
     <value>Current Weather</value>
   </data>
+  <data name="dock_band_subtitle_title" xml:space="preserve">
+    <value>Dock Band Subtitle</value>
+  </data>
+  <data name="dock_band_subtitle_description" xml:space="preserve">
+    <value>Choose what to display in the dock band subtitle</value>
+  </data>
+  <data name="dock_band_subtitle_location" xml:space="preserve">
+    <value>Location Name</value>
+  </data>
+  <data name="dock_band_subtitle_highlow" xml:space="preserve">
+    <value>High/Low Temperatures</value>
+  </data>
   <data name="loading_data" xml:space="preserve">
     <value>Loading weather data...</value>
   </data>

--- a/WeatherExtension/Services/WeatherSettingsManager.cs
+++ b/WeatherExtension/Services/WeatherSettingsManager.cs
@@ -49,6 +49,15 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
             new ChoiceSetSetting.Choice(Resources.twelve_hours, "720"),
         ]);
 
+    private readonly ChoiceSetSetting _dockBandSubtitle = new(
+        Namespaced(nameof(DockBandSubtitle)),
+        Resources.dock_band_subtitle_title,
+        Resources.dock_band_subtitle_description,
+        [
+            new ChoiceSetSetting.Choice(Resources.dock_band_subtitle_location, "location"),
+            new ChoiceSetSetting.Choice(Resources.dock_band_subtitle_highlow, "highlow"),
+        ]);
+
     private static readonly HashSet<string> _validIntervals = ["60", "180", "360", "720"];
 
     public string TemperatureUnit => _temperatureUnit.Value ?? "celsius";
@@ -59,6 +68,8 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
 
     public int UpdateIntervalMinutes => _updateInterval.Value is string v && _validIntervals.Contains(v) ? int.Parse(v, System.Globalization.CultureInfo.InvariantCulture) : 60;
 
+    public string DockBandSubtitle => _dockBandSubtitle.Value ?? "highlow";
+
     public WeatherSettingsManager()
     {
         FilePath = SettingsJsonPath();
@@ -67,6 +78,7 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
         Settings.Add(_windSpeedUnit);
         Settings.Add(_showForecast);
         Settings.Add(_updateInterval);
+        Settings.Add(_dockBandSubtitle);
 
         LoadSettings();
         MigrateUpdateInterval();
@@ -82,6 +94,7 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
         Settings.Add(_windSpeedUnit);
         Settings.Add(_showForecast);
         Settings.Add(_updateInterval);
+        Settings.Add(_dockBandSubtitle);
 
         LoadSettings();
         MigrateUpdateInterval();

--- a/WeatherExtension/Services/WeatherSettingsManager.cs
+++ b/WeatherExtension/Services/WeatherSettingsManager.cs
@@ -54,8 +54,8 @@ public sealed class WeatherSettingsManager : JsonSettingsManager
         Resources.dock_band_subtitle_title,
         Resources.dock_band_subtitle_description,
         [
-            new ChoiceSetSetting.Choice(Resources.dock_band_subtitle_location, "location"),
             new ChoiceSetSetting.Choice(Resources.dock_band_subtitle_highlow, "highlow"),
+            new ChoiceSetSetting.Choice(Resources.dock_band_subtitle_location, "location"),
         ]);
 
     private static readonly HashSet<string> _validIntervals = ["60", "180", "360", "720"];


### PR DESCRIPTION
## Summary

Adds a user-facing setting to control what the dock band subtitle displays.

## Changes

### New Setting: `DockBandSubtitle`
- **Location Name** — shows the location name (e.g. `Birmingham, Alabama`)
- **High/Low Temperatures** (default) — shows the day's high and low temps (e.g. `H: 85°F  L: 62°F`)

### Files Changed
- **`WeatherSettingsManager.cs`** — new `ChoiceSetSetting` with `"location"` and `"highlow"` options, defaulting to `"highlow"`
- **`PinnedWeatherBand.cs`** — subtitle logic branches on the setting; when `"location"` is selected, the forecast API call is skipped entirely (saves a network request)
- **`Resources.resx` / `Resources.Designer.cs`** — 4 new resource strings for the setting UI

## Behavior

| Setting | Subtitle | Forecast API call |
|---------|----------|-------------------|
| High/Low Temps (default) | `H: 85°F  L: 62°F` | Yes |
| Location Name | `Birmingham, Alabama` | Skipped |

Error/loading states are unchanged — they always show location + error message.

Closes #84