### PR TITLE
Store publish now uploads MSIX files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Submit to Microsoft Store
         shell: pwsh
         run: |
-          msstore publish WeatherExtension -i msix-packages -nc -id "${{ secrets.STORE_PRODUCT_ID }}"
+          msstore publish WeatherExtension -i msix-packages -id "${{ secrets.STORE_PRODUCT_ID }}"
 
   winget-publish:
     needs: [package, build-and-test]


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by removing the `-nc` flag from the Microsoft Store publishing step in `.github/workflows/release.yml`. This change simplifies the publish command and may affect how the package is submitted to the Microsoft Store.

- Workflow update:
  * Removed the `-nc` (no commit) flag from the `msstore publish` command in the Microsoft Store submission step of the release workflow (`.github/workflows/release.yml`).