### PR TITLE
fix: show error message when weather data is null

### DIFF
--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -149,6 +149,12 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 			if (weatherData?.Current == null)
 			{
+				EmptyContent = new ListItem(new NoOpCommand())
+				{
+					Title = Resources.weather_service_error,
+					Icon = Icons.WeatherIcon,
+				};
+
 				lock (_sync)
 				{
 					_isLoading = false;


### PR DESCRIPTION
Closes #92

## Summary
When `GetCurrentWeatherAsync` returns null (API failure, no data), `WeatherListPage.LoadWeatherForLocation` now sets `EmptyContent` with a 'Weather service unavailable' message instead of leaving the user with a blank page.

## Change
6 lines added to set `EmptyContent` in the null-data path, using the existing `Resources.weather_service_error` string and same `ListItem(NoOpCommand)` pattern used elsewhere in the file.