### PR TITLE
feat: incrementally load favorites as weather data arrives

### DIFF
--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -85,8 +85,12 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 			EmptyContent = null;
 
+			lock (_sync)
+			{
+				_items = [];
+			}
+
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(searchCt, _cts.Token);
-			var items = new List<IListItem>();
 
 			foreach (var pinned in favorites)
 			{
@@ -102,7 +106,12 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 					if (weatherData != null)
 					{
-						items.Add(CreateWeatherItem(location, weatherData));
+						lock (_sync)
+						{
+							_items = [.. _items, CreateWeatherItem(location, weatherData)];
+						}
+
+						RaiseItemsChanged();
 					}
 				}
 				catch (Exception ex) when (ex is not OperationCanceledException)
@@ -115,7 +124,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 			lock (_sync)
 			{
-				_items = items.ToArray();
 				_isLoading = false;
 			}
 


### PR DESCRIPTION
Closes #93

## Summary
Favorites now appear one-by-one as each weather API call completes, rather than waiting for all calls to finish before showing anything.

## Change
- Removed intermediate `List<IListItem>` accumulator
- Each successful fetch appends to `_items` under lock and fires `RaiseItemsChanged()` immediately
- Users with 3+ favorites on slow connections see results pop in progressively instead of staring at a blank list

## Impact
Perceived performance improvement for all users with favorites. No functional change — same data, same items, just shown sooner.