### PR TITLE
fix(weather): InvariantCulture for Open-Meteo API URLs

### DIFF
--- a/WeatherExtension.Tests/OpenMeteoServiceCultureTests.cs
+++ b/WeatherExtension.Tests/OpenMeteoServiceCultureTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using Microsoft.CmdPal.Ext.Weather.Services;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class OpenMeteoServiceCultureTests
+{
+	private const string MinimalCurrentWeatherJson = """
+		{
+			"latitude": 41.0,
+			"longitude": 28.97,
+			"current": {
+				"time": "2026-05-20T12:00",
+				"temperature_2m": 22.0,
+				"relative_humidity_2m": 60,
+				"apparent_temperature": 22.0,
+				"weather_code": 0,
+				"wind_speed_10m": 5.0,
+				"wind_direction_10m": 180
+			}
+		}
+		""";
+
+	[TestMethod]
+	public async Task GetCurrentWeatherAsync_UnderTurkishCulture_FormatsCoordinatesWithDots()
+	{
+		var originalCulture = Thread.CurrentThread.CurrentCulture;
+		Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+		try
+		{
+			Uri? capturedUri = null;
+			var handler = new RecordingHandler(request =>
+			{
+				capturedUri = request.RequestUri;
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent(MinimalCurrentWeatherJson),
+				};
+			});
+
+			using var service = new OpenMeteoService(handler);
+			var result = await service.GetCurrentWeatherAsync(41.0063810, 28.9758715, "celsius", "kmh", CancellationToken.None);
+
+			Assert.IsNotNull(capturedUri, "Expected the service to make an HTTP request.");
+			AssertCoordinatesAreInvariant(capturedUri!, expectedLat: "41.006381", expectedLon: "28.9758715");
+			Assert.IsNotNull(result, "Successful 200 response should deserialize.");
+		}
+		finally
+		{
+			Thread.CurrentThread.CurrentCulture = originalCulture;
+		}
+	}
+
+	[TestMethod]
+	public async Task GetForecastAsync_UnderTurkishCulture_FormatsCoordinatesWithDots()
+	{
+		var originalCulture = Thread.CurrentThread.CurrentCulture;
+		Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+		try
+		{
+			Uri? capturedUri = null;
+			var handler = new RecordingHandler(request =>
+			{
+				capturedUri = request.RequestUri;
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("""{ "latitude":41.0, "longitude":28.97, "daily":{} }"""),
+				};
+			});
+
+			using var service = new OpenMeteoService(handler);
+			await service.GetForecastAsync(41.0063810, 28.9758715, "celsius", CancellationToken.None);
+
+			Assert.IsNotNull(capturedUri);
+			AssertCoordinatesAreInvariant(capturedUri!, expectedLat: "41.006381", expectedLon: "28.9758715");
+		}
+		finally
+		{
+			Thread.CurrentThread.CurrentCulture = originalCulture;
+		}
+	}
+
+	[TestMethod]
+	public async Task GetHourlyForecastAsync_UnderTurkishCulture_FormatsCoordinatesWithDots()
+	{
+		var originalCulture = Thread.CurrentThread.CurrentCulture;
+		Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+		try
+		{
+			Uri? capturedUri = null;
+			var handler = new RecordingHandler(request =>
+			{
+				capturedUri = request.RequestUri;
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("""{ "latitude":41.0, "longitude":28.97, "hourly":{} }"""),
+				};
+			});
+
+			using var service = new OpenMeteoService(handler);
+			await service.GetHourlyForecastAsync(41.0063810, 28.9758715, "celsius", "kmh", CancellationToken.None);
+
+			Assert.IsNotNull(capturedUri);
+			AssertCoordinatesAreInvariant(capturedUri!, expectedLat: "41.006381", expectedLon: "28.9758715");
+		}
+		finally
+		{
+			Thread.CurrentThread.CurrentCulture = originalCulture;
+		}
+	}
+
+	private static void AssertCoordinatesAreInvariant(Uri uri, string expectedLat, string expectedLon)
+	{
+		// Open-Meteo rejects comma-formatted floats with HTTP 400. Coordinates
+		// must always be invariant-culture decimals regardless of OS locale.
+		// We can't assert against the entire query string because parameter list
+		// values legitimately contain commas (e.g. current=temperature_2m,...).
+		var parsed = System.Web.HttpUtility.ParseQueryString(uri.Query);
+
+		var lat = parsed["latitude"];
+		var lon = parsed["longitude"];
+
+		Assert.AreEqual(expectedLat, lat, $"latitude must be dot-formatted regardless of culture. Query='{uri.Query}'");
+		Assert.AreEqual(expectedLon, lon, $"longitude must be dot-formatted regardless of culture. Query='{uri.Query}'");
+		Assert.IsFalse(lat!.Contains(',', StringComparison.Ordinal), "latitude must not contain a culture-specific comma.");
+		Assert.IsFalse(lon!.Contains(',', StringComparison.Ordinal), "longitude must not contain a culture-specific comma.");
+	}
+
+	private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> factory) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return Task.FromResult(factory(request));
+		}
+	}
+}

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -5,6 +5,7 @@
 using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.Models;
 using Microsoft.CommandPalette.Extensions;
+using System.Globalization;
 using System.Text.Json;
 
 namespace Microsoft.CmdPal.Ext.Weather.Services;
@@ -57,7 +58,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 	{
 		try
 		{
-			var cacheKey = $"{latitude},{longitude},{temperatureUnit},{windSpeedUnit}";
+			var cacheKey = FormattableString.Invariant($"{latitude},{longitude},{temperatureUnit},{windSpeedUnit}");
 			lock (_cacheLock)
 			{
 				if (_cachedWeather != null &&
@@ -68,9 +69,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 				}
 			}
 
-			var url = $"{BaseUrl}?latitude={latitude}&longitude={longitude}" +
-					 $"&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m" +
-					 $"&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&timezone=auto";
+			var url = string.Create(
+				CultureInfo.InvariantCulture,
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 
@@ -127,7 +128,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 	{
 		try
 		{
-			var cacheKey = $"{latitude},{longitude},{temperatureUnit}";
+			var cacheKey = FormattableString.Invariant($"{latitude},{longitude},{temperatureUnit}");
 			lock (_cacheLock)
 			{
 				if (_cachedForecast != null &&
@@ -138,9 +139,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 				}
 			}
 
-			var url = $"{BaseUrl}?latitude={latitude}&longitude={longitude}" +
-					 $"&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max" +
-					 $"&temperature_unit={temperatureUnit}&timezone=auto";
+			var url = string.Create(
+				CultureInfo.InvariantCulture,
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&temperature_unit={temperatureUnit}&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 
@@ -198,7 +199,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 	{
 		try
 		{
-			var cacheKey = $"{latitude},{longitude},{temperatureUnit},{windSpeedUnit}";
+			var cacheKey = FormattableString.Invariant($"{latitude},{longitude},{temperatureUnit},{windSpeedUnit}");
 			lock (_cacheLock)
 			{
 				if (_cachedHourly != null &&
@@ -209,9 +210,9 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 				}
 			}
 
-			var url = $"{BaseUrl}?latitude={latitude}&longitude={longitude}" +
-					 $"&hourly=temperature_2m,apparent_temperature,weather_code,precipitation_probability,wind_speed_10m,relative_humidity_2m" +
-					 $"&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&forecast_days=2&timezone=auto";
+			var url = string.Create(
+				CultureInfo.InvariantCulture,
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&hourly=temperature_2m,apparent_temperature,weather_code,precipitation_probability,wind_speed_10m,relative_humidity_2m&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&forecast_days=2&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Format latitude/longitude with \InvariantCulture\ in Open-Meteo request URLs so locales like tr-TR do not break API calls.
- Add \OpenMeteoServiceCultureTests\ (tr-TR regression).

## Stack
Part 1 of splitting #101 into reviewable PRs (foundational; no UI changes).

## Test plan
- [x] \dotnet test --filter OpenMeteo\ (3 tests)


Made with [Cursor](https://cursor.com)