### PR TITLE
feat(weather): geocoding improvements for non-en-US locales

### DIFF
--- a/WeatherExtension.Tests/GeocodingServiceTests.cs
+++ b/WeatherExtension.Tests/GeocodingServiceTests.cs
@@ -191,6 +191,12 @@ public class GeocodingServiceTests
 	}
 
 	[TestMethod]
+	public void MaxFallbackAttempts_IsFiveToAllowSegmentRetry()
+	{
+		Assert.AreEqual(5, GeocodingService.MaxFallbackAttempts);
+	}
+
+	[TestMethod]
 	public async Task SearchLocationAsync_LongCommaInput_CapsAttemptsAtMaxFallbackAttempts()
 	{
 		var callCount = 0;
@@ -342,7 +348,9 @@ public class GeocodingServiceTests
 		var results = await service.SearchLocationAsync("90210", CancellationToken.None);
 
 		Assert.IsTrue(results.Count > 0, "Expected non-empty results from Photon fallback for postal code");
-		Assert.AreEqual(2, callCount, "Expected 1 failed Nominatim postal-code call + 1 successful Photon call");
+		// The postal code path tries Nominatim's postalcode= endpoint, then a
+		// free-text Nominatim retry, before finally falling back to Photon.
+		Assert.AreEqual(3, callCount, "Expected 2 failed Nominatim postal-code calls + 1 successful Photon call");
 	}
 
 	[TestMethod]
@@ -362,6 +370,180 @@ public class GeocodingServiceTests
 		Assert.IsTrue(
 			callCount <= GeocodingService.MaxFallbackAttempts,
 			$"Expected at most {GeocodingService.MaxFallbackAttempts} HTTP calls, got {callCount}");
+	}
+
+	// ── Header policy / locale stability ───────────────────────────────────
+
+	[TestMethod]
+	public async Task SearchLocationAsync_SendsContactUserAgentAndAcceptLanguage()
+	{
+		HttpRequestMessage? captured = null;
+		var handler = new CountingHttpHandler(
+			_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") },
+			request => captured ??= request);
+
+		using var service = new GeocodingService(handler);
+		await service.SearchLocationAsync("Seattle", CancellationToken.None);
+
+		Assert.IsNotNull(captured, "Expected at least one outgoing request");
+
+		var ua = string.Join(' ', captured!.Headers.UserAgent.Select(p => p.ToString()));
+		Assert.IsTrue(
+			ua.Contains("PowerToys-CmdPal-Weather", StringComparison.Ordinal),
+			$"User-Agent should identify the extension. Got: '{ua}'");
+		Assert.IsTrue(
+			ua.Contains("github.com", StringComparison.OrdinalIgnoreCase),
+			$"User-Agent should include a contact URL per Nominatim policy. Got: '{ua}'");
+
+		var acceptLang = string.Join(',', captured.Headers.AcceptLanguage.Select(v => v.Value));
+		Assert.IsTrue(
+			acceptLang.Contains("en", StringComparison.OrdinalIgnoreCase),
+			$"Accept-Language should request English to keep display names stable. Got: '{acceptLang}'");
+	}
+
+	// ── Postal code free-text retry ────────────────────────────────────────
+
+	private const string ValidNominatimIstanbulPostcodeJson = """
+		[{
+			"place_id": 378361098,
+			"licence": "Data",
+			"lat": "41.0077058",
+			"lon": "28.9795504",
+			"class": "boundary",
+			"type": "postal_code",
+			"name": "34122",
+			"display_name": "34122, Cankurtaran Mahallesi, İstanbul, Fatih, İstanbul, Marmara Bölgesi, Türkiye",
+			"address": {
+				"postcode": "34122",
+				"suburb": "Cankurtaran Mahallesi",
+				"city": "İstanbul",
+				"town": "Fatih",
+				"country": "Türkiye",
+				"country_code": "tr"
+			}
+		}]
+		""";
+
+	[TestMethod]
+	public async Task SearchLocationAsync_PostalCodePath_PrefersAddressLocalityForName()
+	{
+		var handler = new CountingHttpHandler(request =>
+		{
+			Assert.IsTrue(request.RequestUri!.Host.Contains("nominatim", StringComparison.OrdinalIgnoreCase));
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(ValidNominatimIstanbulPostcodeJson),
+			};
+		});
+
+		using var service = new GeocodingService(handler);
+		var results = await service.SearchLocationAsync("34122", CancellationToken.None);
+
+		Assert.AreEqual(1, results.Count);
+		// Prior code surfaced the postcode itself ("34122") as Name, hiding
+		// the actual locality. The address-derived name keeps results readable.
+		Assert.AreEqual("İstanbul", results[0].Name);
+		Assert.AreEqual("TR", results[0].CountryCode);
+	}
+
+	[TestMethod]
+	public async Task SearchLocationAsync_PostalCodeEmpty_RetriesAsFreeTextNominatim()
+	{
+		var requestUris = new List<Uri>();
+		var nominatimCalls = 0;
+		var handler = new CountingHttpHandler(
+			request =>
+			{
+				if (request.RequestUri!.Host.Contains("nominatim", StringComparison.OrdinalIgnoreCase))
+				{
+					nominatimCalls++;
+					var query = request.RequestUri.Query;
+					// First call uses postalcode=, second uses q=
+					if (query.Contains("postalcode=", StringComparison.Ordinal))
+					{
+						return new HttpResponseMessage(HttpStatusCode.OK)
+						{
+							Content = new StringContent("[]"),
+						};
+					}
+
+					return new HttpResponseMessage(HttpStatusCode.OK)
+					{
+						Content = new StringContent(ValidNominatimIstanbulPostcodeJson),
+					};
+				}
+
+				Assert.Fail("Photon should not be reached when free-text Nominatim retry succeeds.");
+				return new HttpResponseMessage(HttpStatusCode.OK);
+			},
+			request => requestUris.Add(request.RequestUri!));
+
+		using var service = new GeocodingService(handler);
+		var results = await service.SearchLocationAsync("34122", CancellationToken.None);
+
+		Assert.AreEqual(2, nominatimCalls, "Expected one postalcode= call followed by one free-text q= retry.");
+		Assert.IsTrue(results.Count > 0, "Free-text Nominatim retry should surface postal code results.");
+		Assert.IsTrue(requestUris[0].Query.Contains("postalcode=", StringComparison.Ordinal));
+		Assert.IsTrue(requestUris[1].Query.Contains("q=", StringComparison.Ordinal));
+	}
+
+	// ── Photon broad retry when osm_tag=place returns nothing ──────────────
+
+	private const string ValidPhotonGenericLocationJson = """
+		{
+			"type": "FeatureCollection",
+			"features": [
+				{
+					"type": "Feature",
+					"geometry": { "type": "Point", "coordinates": [28.9784, 41.0082] },
+					"properties": {
+						"name": "İstanbul",
+						"country": "Türkiye",
+						"osm_key": "boundary",
+						"osm_value": "administrative"
+					}
+				}
+			]
+		}
+		""";
+
+	[TestMethod]
+	public async Task SearchLocationAsync_PhotonPlaceFilterEmpty_RetriesWithoutFilter()
+	{
+		var photonQueries = new List<string>();
+		var handler = new CountingHttpHandler(request =>
+		{
+			if (request.RequestUri!.Host.Contains("nominatim", StringComparison.OrdinalIgnoreCase))
+			{
+				return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+			}
+
+			var query = Uri.UnescapeDataString(request.RequestUri.Query);
+			photonQueries.Add(query);
+
+			// First Photon call uses osm_tag=place and returns nothing.
+			// The retry without that filter should succeed.
+			if (query.Contains("osm_tag=place", StringComparison.Ordinal))
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("""{ "type":"FeatureCollection", "features":[] }"""),
+				};
+			}
+
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(ValidPhotonGenericLocationJson),
+			};
+		});
+
+		using var service = new GeocodingService(handler);
+		var results = await service.SearchLocationAsync("istanbul", CancellationToken.None);
+
+		Assert.IsTrue(results.Count > 0, "Broad Photon retry should surface results when place-filter is empty.");
+		Assert.AreEqual(2, photonQueries.Count, "Expected exactly two Photon calls: place-filtered then broad.");
+		Assert.IsTrue(photonQueries[0].Contains("osm_tag=place", StringComparison.Ordinal));
+		Assert.IsFalse(photonQueries[1].Contains("osm_tag=place", StringComparison.Ordinal));
 	}
 
 }

--- a/WeatherExtension/Services/GeocodingService.cs
+++ b/WeatherExtension/Services/GeocodingService.cs
@@ -16,7 +16,11 @@ public sealed partial class GeocodingService : IGeocodingService
 	private const string NominatimUrl = "https://nominatim.openstreetmap.org/search";
 	private const string PhotonUrl = "https://photon.komoot.io/api/";
 	private const int MinSearchLength = 3;
-	internal const int MaxFallbackAttempts = 3;
+	// Worst case per comma-trimmed query segment: Nominatim (1) + Photon places (1)
+	// + Photon broad retry (1) = 3 HTTP calls. A budget of 4 left only one slot for
+	// the next segment (Nominatim-only, no Photon retries). 5 allows one full
+	// three-call pass plus a trimmed-segment retry with Nominatim + Photon places.
+	internal const int MaxFallbackAttempts = 5;
 
 	[GeneratedRegex(@"^\d{5}(-\d{4})?$")]
 	private static partial Regex UsZipCodeRegex();
@@ -41,7 +45,17 @@ public sealed partial class GeocodingService : IGeocodingService
 		{
 			Timeout = TimeSpan.FromSeconds(10),
 		};
-		_httpClient.DefaultRequestHeaders.Add("User-Agent", "PowerToys-CmdPal-Weather/1.0");
+
+		// Nominatim Usage Policy requires a meaningful User-Agent that identifies
+		// the application and includes a contact. Stock library UAs are blocked.
+		// https://operations.osmfoundation.org/policies/nominatim/
+		_httpClient.DefaultRequestHeaders.Add(
+			"User-Agent",
+			"PowerToys-CmdPal-Weather/1.0 (+https://github.com/michaeljolley/WeatherExtension)");
+
+		// Ask providers for a stable English display_name so result formatting and
+		// ranking aren't culture-sensitive (avoids Turkish dotless-i style folding).
+		_httpClient.DefaultRequestHeaders.Add("Accept-Language", "en");
 	}
 
 	public async Task<List<GeocodingResult>> SearchLocationAsync(string query, CancellationToken ct = default)
@@ -89,9 +103,9 @@ public sealed partial class GeocodingService : IGeocodingService
 	private async Task<List<GeocodingResult>> SearchWithProgressiveFallbackAsync(string query, CancellationToken ct)
 	{
 		var currentQuery = query;
-		// MaxFallbackAttempts caps the total number of outbound HTTP calls across
-		// both Nominatim and Photon combined, not per-provider. Each provider call
-		// consumes one slot from this budget.
+		// MaxFallbackAttempts caps outbound HTTP calls across Nominatim and Photon
+		// for this search (not per-provider). Each call consumes one slot. See the
+		// constant comment for per-segment worst-case math (3 calls/segment).
 		var remainingCalls = MaxFallbackAttempts;
 		var nominatimAlive = true;
 
@@ -139,6 +153,21 @@ public sealed partial class GeocodingService : IGeocodingService
 				return photonResults;
 			}
 
+			// Photon's place-only filter silently drops cities that OSM doesn't
+			// tag with osm_tag=place (common for non-English locality names).
+			// Retry once without the filter when budget allows before falling back.
+			if (remainingCalls > 0)
+			{
+				ct.ThrowIfCancellationRequested();
+				var broadResults = await SearchPhotonAsync(currentQuery, placesOnly: false, ct).ConfigureAwait(false);
+				remainingCalls--;
+
+				if (broadResults.Count > 0)
+				{
+					return broadResults;
+				}
+			}
+
 			// Strip the last comma-separated segment and retry
 			var lastComma = currentQuery.LastIndexOf(',');
 			if (lastComma <= 0)
@@ -169,7 +198,7 @@ public sealed partial class GeocodingService : IGeocodingService
 
 			if (!response.IsSuccessStatusCode)
 			{
-				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
+				return await SearchPostalCodeFallbackAsync(postalCode, ct).ConfigureAwait(false);
 			}
 
 			var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
@@ -180,12 +209,12 @@ public sealed partial class GeocodingService : IGeocodingService
 				WeatherLogger.LogToHost(
 					MessageState.Info,
 					$"Nominatim deserialization returned null. Status: {response.StatusCode}, Content length: {content.Length}");
-				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
+				return await SearchPostalCodeFallbackAsync(postalCode, ct).ConfigureAwait(false);
 			}
 
 			if (nominatimResults.Count == 0)
 			{
-				return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
+				return await SearchPostalCodeFallbackAsync(postalCode, ct).ConfigureAwait(false);
 			}
 
 			return ConvertNominatimResults(nominatimResults);
@@ -195,8 +224,32 @@ public sealed partial class GeocodingService : IGeocodingService
 			WeatherLogger.LogToHost(
 				MessageState.Error,
 				$"Nominatim postal code lookup error: {ex.Message}");
-			return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
+			return await SearchPostalCodeFallbackAsync(postalCode, ct).ConfigureAwait(false);
 		}
+	}
+
+	// Postal codes are notoriously inconsistent across providers. When the
+	// Nominatim postalcode= endpoint comes up empty (e.g. blocked, rate-limited,
+	// or the postal code isn't tagged as a postcode in OSM), retry as a regular
+	// free-text Nominatim search before falling back to Photon.
+	private async Task<List<GeocodingResult>> SearchPostalCodeFallbackAsync(string postalCode, CancellationToken ct)
+	{
+		try
+		{
+			var freeTextResults = await SearchNominatimAsync(postalCode, ct).ConfigureAwait(false);
+			if (freeTextResults.Count > 0)
+			{
+				return freeTextResults;
+			}
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Info,
+				$"Nominatim free-text postal code retry failed: {ex.Message}");
+		}
+
+		return await SearchPhotonAsync(postalCode, placesOnly: false, ct).ConfigureAwait(false);
 	}
 
 	private async Task<List<GeocodingResult>> SearchNominatimAsync(string query, CancellationToken ct)
@@ -315,10 +368,15 @@ public sealed partial class GeocodingService : IGeocodingService
 
 		foreach (var nr in nominatimResults)
 		{
-			var rawPlaceName = nr.Name
-				?? nr.Address?.City
+			// When the user searched by postal code, Nominatim sets Name to the
+			// postal code itself ("34122"). Prefer the actual locality so list
+			// items show "İstanbul" rather than just the postcode.
+			var addressLocality = nr.Address?.City
 				?? nr.Address?.Town
-				?? nr.Address?.Village
+				?? nr.Address?.Village;
+
+			var rawPlaceName = addressLocality
+				?? nr.Name
 				?? nr.DisplayName?.Split(',')[0].Trim();
 
 			if (string.IsNullOrWhiteSpace(rawPlaceName))


### PR DESCRIPTION
## Summary
GeocodingService: User-Agent, Accept-Language, postal retry; MaxFallbackAttempts=5.

## Merge order
1. After #102 (InvariantCulture) optional — standalone
2. Before i18n/formatter/settings stack

## Test plan
- [x] GeocodingServiceTests

Made with [Cursor](https://cursor.com)