### PR TITLE
refactor(weather): WeatherDescriptions and WeatherFormatter

### DIFF
--- a/WeatherExtension.Tests/IconsTests.cs
+++ b/WeatherExtension.Tests/IconsTests.cs
@@ -2,224 +2,86 @@
 // Bald Bearded Builder LLC licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 
 [TestClass]
 public class IconsTests
 {
-    [TestMethod]
-    public void GetWeatherDescription_ClearSky_ReturnsCorrectDescription()
+    // GetWeatherDescription used to return one string per WMO code (29 distinct
+    // strings). That made every supported language ship 29 translations and
+    // produced low-value variations like "Slight rain" / "Moderate rain" /
+    // "Heavy rain" — the icon already conveys intensity. The descriptions are
+    // now grouped into 11 broad categories. These tests pin every WMO code in
+    // the open-meteo schema to the category we expect.
+    //
+    // Tests run with the invariant culture so we assert against the neutral
+    // (English) resx without having to ship a fixed culture in test setup.
+
+    private CultureInfo? _originalUiCulture;
+
+    [TestInitialize]
+    public void Setup()
     {
-        var result = Icons.GetWeatherDescription(0);
-        Assert.AreEqual("Clear sky", result);
+        _originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (_originalUiCulture != null)
+        {
+            CultureInfo.CurrentUICulture = _originalUiCulture;
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow(0, "Clear sky")]
+    [DataRow(1, "Mainly clear")]
+    [DataRow(2, "Partly cloudy")]
+    [DataRow(3, "Overcast")]
+    [DataRow(45, "Fog")]
+    [DataRow(48, "Fog")]
+    [DataRow(51, "Drizzle")]
+    [DataRow(53, "Drizzle")]
+    [DataRow(55, "Drizzle")]
+    [DataRow(56, "Drizzle")]
+    [DataRow(57, "Drizzle")]
+    [DataRow(61, "Rain")]
+    [DataRow(63, "Rain")]
+    [DataRow(65, "Rain")]
+    [DataRow(66, "Rain")]
+    [DataRow(67, "Rain")]
+    [DataRow(71, "Snow")]
+    [DataRow(73, "Snow")]
+    [DataRow(75, "Snow")]
+    [DataRow(77, "Snow")]
+    [DataRow(80, "Rain showers")]
+    [DataRow(81, "Rain showers")]
+    [DataRow(82, "Rain showers")]
+    [DataRow(85, "Snow showers")]
+    [DataRow(86, "Snow showers")]
+    [DataRow(95, "Thunderstorm")]
+    [DataRow(96, "Thunderstorm")]
+    [DataRow(99, "Thunderstorm")]
+    public void GetWeatherDescription_KnownCode_ReturnsExpectedCategory(int weatherCode, string expected)
+    {
+        Assert.AreEqual(expected, Icons.GetWeatherDescription(weatherCode));
+    }
+
+    [DataTestMethod]
+    [DataRow(999)]
+    [DataRow(-1)]
+    [DataRow(int.MaxValue)]
+    public void GetWeatherDescription_UnknownCode_ReturnsUnknown(int weatherCode)
+    {
+        Assert.AreEqual("Unknown", Icons.GetWeatherDescription(weatherCode));
     }
 
     [TestMethod]
-    public void GetWeatherDescription_MainlyClear_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(1);
-        Assert.AreEqual("Mainly clear", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_PartlyCloudy_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(2);
-        Assert.AreEqual("Partly cloudy", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_Overcast_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(3);
-        Assert.AreEqual("Overcast", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_Fog_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(45);
-        Assert.AreEqual("Fog", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_DepositingRimeFog_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(48);
-        Assert.AreEqual("Depositing rime fog", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_LightDrizzle_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(51);
-        Assert.AreEqual("Light drizzle", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ModerateDrizzle_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(53);
-        Assert.AreEqual("Moderate drizzle", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_DenseDrizzle_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(55);
-        Assert.AreEqual("Dense drizzle", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_LightFreezingDrizzle_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(56);
-        Assert.AreEqual("Light freezing drizzle", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_DenseFreezingDrizzle_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(57);
-        Assert.AreEqual("Dense freezing drizzle", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_SlightRain_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(61);
-        Assert.AreEqual("Slight rain", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ModerateRain_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(63);
-        Assert.AreEqual("Moderate rain", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_HeavyRain_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(65);
-        Assert.AreEqual("Heavy rain", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_LightFreezingRain_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(66);
-        Assert.AreEqual("Light freezing rain", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_HeavyFreezingRain_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(67);
-        Assert.AreEqual("Heavy freezing rain", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_SlightSnowFall_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(71);
-        Assert.AreEqual("Slight snow fall", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ModerateSnowFall_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(73);
-        Assert.AreEqual("Moderate snow fall", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_HeavySnowFall_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(75);
-        Assert.AreEqual("Heavy snow fall", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_SnowGrains_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(77);
-        Assert.AreEqual("Snow grains", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_SlightRainShowers_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(80);
-        Assert.AreEqual("Slight rain showers", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ModerateRainShowers_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(81);
-        Assert.AreEqual("Moderate rain showers", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ViolentRainShowers_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(82);
-        Assert.AreEqual("Violent rain showers", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_SlightSnowShowers_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(85);
-        Assert.AreEqual("Slight snow showers", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_HeavySnowShowers_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(86);
-        Assert.AreEqual("Heavy snow showers", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_Thunderstorm_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(95);
-        Assert.AreEqual("Thunderstorm", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ThunderstormWithSlightHail_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(96);
-        Assert.AreEqual("Thunderstorm with slight hail", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_ThunderstormWithHeavyHail_ReturnsCorrectDescription()
-    {
-        var result = Icons.GetWeatherDescription(99);
-        Assert.AreEqual("Thunderstorm with heavy hail", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_UnknownCode_ReturnsUnknown()
-    {
-        var result = Icons.GetWeatherDescription(999);
-        Assert.AreEqual("Unknown", result);
-    }
-
-    [TestMethod]
-    public void GetWeatherDescription_NegativeCode_ReturnsUnknown()
-    {
-        var result = Icons.GetWeatherDescription(-1);
-        Assert.AreEqual("Unknown", result);
-    }
-
-    [TestMethod]
-    public void GetIconForWeatherCode_ClearSky_ReturnsNotNull()
+    public void GetIconForWeatherCode_ClearSky_ReturnsClearSkyIcon()
     {
         var result = Icons.GetIconForWeatherCode(0);
         Assert.IsNotNull(result);
@@ -227,147 +89,96 @@ public class IconsTests
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_MainlyClear_ReturnsNotNull()
+    public void GetIconForWeatherCode_MainlyClear_GroupsCodes1And2()
     {
-        var result1 = Icons.GetIconForWeatherCode(1);
-        var result2 = Icons.GetIconForWeatherCode(2);
-        Assert.IsNotNull(result1);
-        Assert.IsNotNull(result2);
-        Assert.AreEqual(Icons.MainlyClear, result1);
-        Assert.AreEqual(Icons.MainlyClear, result2);
+        Assert.AreEqual(Icons.MainlyClear, Icons.GetIconForWeatherCode(1));
+        Assert.AreEqual(Icons.MainlyClear, Icons.GetIconForWeatherCode(2));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_PartlyCloudy_ReturnsNotNull()
+    public void GetIconForWeatherCode_PartlyCloudy_ReturnsPartlyCloudyIcon()
     {
-        var result = Icons.GetIconForWeatherCode(3);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(Icons.PartlyCloudy, result);
+        Assert.AreEqual(Icons.PartlyCloudy, Icons.GetIconForWeatherCode(3));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_Fog_ReturnsNotNull()
+    public void GetIconForWeatherCode_Fog_GroupsCodes45And48()
     {
-        var result45 = Icons.GetIconForWeatherCode(45);
-        var result48 = Icons.GetIconForWeatherCode(48);
-        Assert.IsNotNull(result45);
-        Assert.IsNotNull(result48);
-        Assert.AreEqual(Icons.Fog, result45);
-        Assert.AreEqual(Icons.Fog, result48);
+        Assert.AreEqual(Icons.Fog, Icons.GetIconForWeatherCode(45));
+        Assert.AreEqual(Icons.Fog, Icons.GetIconForWeatherCode(48));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_Drizzle_ReturnsNotNull()
+    public void GetIconForWeatherCode_Drizzle_GroupsCodes51To55()
     {
-        var result51 = Icons.GetIconForWeatherCode(51);
-        var result53 = Icons.GetIconForWeatherCode(53);
-        var result55 = Icons.GetIconForWeatherCode(55);
-        Assert.IsNotNull(result51);
-        Assert.IsNotNull(result53);
-        Assert.IsNotNull(result55);
-        Assert.AreEqual(Icons.Drizzle, result51);
+        Assert.AreEqual(Icons.Drizzle, Icons.GetIconForWeatherCode(51));
+        Assert.AreEqual(Icons.Drizzle, Icons.GetIconForWeatherCode(53));
+        Assert.AreEqual(Icons.Drizzle, Icons.GetIconForWeatherCode(55));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_FreezingDrizzle_ReturnsNotNull()
+    public void GetIconForWeatherCode_FreezingDrizzle_GroupsCodes56And57()
     {
-        var result56 = Icons.GetIconForWeatherCode(56);
-        var result57 = Icons.GetIconForWeatherCode(57);
-        Assert.IsNotNull(result56);
-        Assert.IsNotNull(result57);
-        Assert.AreEqual(Icons.DrizzleFreezing, result56);
+        Assert.AreEqual(Icons.DrizzleFreezing, Icons.GetIconForWeatherCode(56));
+        Assert.AreEqual(Icons.DrizzleFreezing, Icons.GetIconForWeatherCode(57));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_Rain_ReturnsNotNull()
+    public void GetIconForWeatherCode_Rain_GroupsCodes61To65()
     {
-        var result61 = Icons.GetIconForWeatherCode(61);
-        var result63 = Icons.GetIconForWeatherCode(63);
-        var result65 = Icons.GetIconForWeatherCode(65);
-        Assert.IsNotNull(result61);
-        Assert.IsNotNull(result63);
-        Assert.IsNotNull(result65);
-        Assert.AreEqual(Icons.Rain, result61);
+        Assert.AreEqual(Icons.Rain, Icons.GetIconForWeatherCode(61));
+        Assert.AreEqual(Icons.Rain, Icons.GetIconForWeatherCode(63));
+        Assert.AreEqual(Icons.Rain, Icons.GetIconForWeatherCode(65));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_FreezingRain_ReturnsNotNull()
+    public void GetIconForWeatherCode_FreezingRain_GroupsCodes66And67()
     {
-        var result66 = Icons.GetIconForWeatherCode(66);
-        var result67 = Icons.GetIconForWeatherCode(67);
-        Assert.IsNotNull(result66);
-        Assert.IsNotNull(result67);
-        Assert.AreEqual(Icons.RainFreezing, result66);
+        Assert.AreEqual(Icons.RainFreezing, Icons.GetIconForWeatherCode(66));
+        Assert.AreEqual(Icons.RainFreezing, Icons.GetIconForWeatherCode(67));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_Snow_ReturnsNotNull()
+    public void GetIconForWeatherCode_Snow_GroupsCodes71To77()
     {
-        var result71 = Icons.GetIconForWeatherCode(71);
-        var result73 = Icons.GetIconForWeatherCode(73);
-        var result75 = Icons.GetIconForWeatherCode(75);
-        var result77 = Icons.GetIconForWeatherCode(77);
-        Assert.IsNotNull(result71);
-        Assert.IsNotNull(result73);
-        Assert.IsNotNull(result75);
-        Assert.IsNotNull(result77);
-        Assert.AreEqual(Icons.Snow, result71);
+        Assert.AreEqual(Icons.Snow, Icons.GetIconForWeatherCode(71));
+        Assert.AreEqual(Icons.Snow, Icons.GetIconForWeatherCode(73));
+        Assert.AreEqual(Icons.Snow, Icons.GetIconForWeatherCode(75));
+        Assert.AreEqual(Icons.Snow, Icons.GetIconForWeatherCode(77));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_RainShowers_ReturnsNotNull()
+    public void GetIconForWeatherCode_RainShowers_GroupsCodes80To82()
     {
-        var result80 = Icons.GetIconForWeatherCode(80);
-        var result81 = Icons.GetIconForWeatherCode(81);
-        var result82 = Icons.GetIconForWeatherCode(82);
-        Assert.IsNotNull(result80);
-        Assert.IsNotNull(result81);
-        Assert.IsNotNull(result82);
-        Assert.AreEqual(Icons.RainShowers, result80);
+        Assert.AreEqual(Icons.RainShowers, Icons.GetIconForWeatherCode(80));
+        Assert.AreEqual(Icons.RainShowers, Icons.GetIconForWeatherCode(81));
+        Assert.AreEqual(Icons.RainShowers, Icons.GetIconForWeatherCode(82));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_SnowShowers_ReturnsNotNull()
+    public void GetIconForWeatherCode_SnowShowers_GroupsCodes85And86()
     {
-        var result85 = Icons.GetIconForWeatherCode(85);
-        var result86 = Icons.GetIconForWeatherCode(86);
-        Assert.IsNotNull(result85);
-        Assert.IsNotNull(result86);
-        Assert.AreEqual(Icons.SnowShowers, result85);
+        Assert.AreEqual(Icons.SnowShowers, Icons.GetIconForWeatherCode(85));
+        Assert.AreEqual(Icons.SnowShowers, Icons.GetIconForWeatherCode(86));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_Thunderstorm_ReturnsNotNull()
+    public void GetIconForWeatherCode_Thunderstorm_ReturnsThunderstormIcon()
     {
-        var result = Icons.GetIconForWeatherCode(95);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(Icons.Thunderstorm, result);
+        Assert.AreEqual(Icons.Thunderstorm, Icons.GetIconForWeatherCode(95));
     }
 
     [TestMethod]
-    public void GetIconForWeatherCode_ThunderstormHail_ReturnsNotNull()
+    public void GetIconForWeatherCode_ThunderstormHail_GroupsCodes96And99()
     {
-        var result96 = Icons.GetIconForWeatherCode(96);
-        var result99 = Icons.GetIconForWeatherCode(99);
-        Assert.IsNotNull(result96);
-        Assert.IsNotNull(result99);
-        Assert.AreEqual(Icons.ThunderstormHail, result96);
-        Assert.AreEqual(Icons.ThunderstormHail, result99);
+        Assert.AreEqual(Icons.ThunderstormHail, Icons.GetIconForWeatherCode(96));
+        Assert.AreEqual(Icons.ThunderstormHail, Icons.GetIconForWeatherCode(99));
     }
 
     [TestMethod]
     public void GetIconForWeatherCode_UnknownCode_ReturnsDefaultWeatherIcon()
     {
-        var result = Icons.GetIconForWeatherCode(999);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(Icons.WeatherIcon, result);
-    }
-
-    [TestMethod]
-    public void GetIconForWeatherCode_NegativeCode_ReturnsDefaultWeatherIcon()
-    {
-        var result = Icons.GetIconForWeatherCode(-1);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(Icons.WeatherIcon, result);
+        Assert.AreEqual(Icons.WeatherIcon, Icons.GetIconForWeatherCode(999));
+        Assert.AreEqual(Icons.WeatherIcon, Icons.GetIconForWeatherCode(-1));
     }
 }

--- a/WeatherExtension.Tests/WeatherDescriptionsTests.cs
+++ b/WeatherExtension.Tests/WeatherDescriptionsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.CmdPal.Ext.Weather.Services;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class WeatherDescriptionsTests
+{
+	[TestMethod]
+	public void GetLocalized_TurkishCulture_ReturnsTranslatedThunderstorm()
+	{
+		var original = CultureInfo.CurrentUICulture;
+		try
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+			Assert.AreEqual("Gök gürültülü", WeatherDescriptions.GetLocalized(95));
+			Assert.AreEqual("Kapalı", WeatherDescriptions.GetLocalized(3));
+			Assert.AreEqual("Sağanak", WeatherDescriptions.GetLocalized(80));
+		}
+		finally
+		{
+			CultureInfo.CurrentUICulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void GetLocalized_EnglishCulture_FallsBackToNeutral()
+	{
+		var original = CultureInfo.CurrentUICulture;
+		try
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			Assert.AreEqual("Thunderstorm", WeatherDescriptions.GetLocalized(95));
+			Assert.AreEqual("Overcast", WeatherDescriptions.GetLocalized(3));
+		}
+		finally
+		{
+			CultureInfo.CurrentUICulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void GetLocalized_UnknownCode_ReturnsLocalizedUnknown()
+	{
+		var original = CultureInfo.CurrentUICulture;
+		try
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+			Assert.AreEqual("Bilinmiyor", WeatherDescriptions.GetLocalized(12345));
+		}
+		finally
+		{
+			CultureInfo.CurrentUICulture = original;
+		}
+	}
+}

--- a/WeatherExtension.Tests/WeatherDescriptionsTests.cs
+++ b/WeatherExtension.Tests/WeatherDescriptionsTests.cs
@@ -11,31 +11,16 @@ namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 public class WeatherDescriptionsTests
 {
 	[TestMethod]
-	public void GetLocalized_TurkishCulture_ReturnsTranslatedThunderstorm()
+	public void GetLocalized_InvariantCulture_ReturnsNeutralCategoryStrings()
 	{
 		var original = CultureInfo.CurrentUICulture;
 		try
 		{
-			CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
-			Assert.AreEqual("Gök gürültülü", WeatherDescriptions.GetLocalized(95));
-			Assert.AreEqual("Kapalı", WeatherDescriptions.GetLocalized(3));
-			Assert.AreEqual("Sağanak", WeatherDescriptions.GetLocalized(80));
-		}
-		finally
-		{
-			CultureInfo.CurrentUICulture = original;
-		}
-	}
-
-	[TestMethod]
-	public void GetLocalized_EnglishCulture_FallsBackToNeutral()
-	{
-		var original = CultureInfo.CurrentUICulture;
-		try
-		{
-			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 			Assert.AreEqual("Thunderstorm", WeatherDescriptions.GetLocalized(95));
 			Assert.AreEqual("Overcast", WeatherDescriptions.GetLocalized(3));
+			Assert.AreEqual("Rain showers", WeatherDescriptions.GetLocalized(80));
+			Assert.AreEqual("Snow showers", WeatherDescriptions.GetLocalized(85));
 		}
 		finally
 		{
@@ -44,13 +29,13 @@ public class WeatherDescriptionsTests
 	}
 
 	[TestMethod]
-	public void GetLocalized_UnknownCode_ReturnsLocalizedUnknown()
+	public void GetLocalized_UnknownCode_ReturnsUnknown()
 	{
 		var original = CultureInfo.CurrentUICulture;
 		try
 		{
-			CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
-			Assert.AreEqual("Bilinmiyor", WeatherDescriptions.GetLocalized(12345));
+			CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+			Assert.AreEqual("Unknown", WeatherDescriptions.GetLocalized(12345));
 		}
 		finally
 		{

--- a/WeatherExtension.Tests/WeatherFormatterTests.cs
+++ b/WeatherExtension.Tests/WeatherFormatterTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.CmdPal.Ext.Weather.Services;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class WeatherFormatterTests
+{
+	[DataTestMethod]
+	[DataRow("celsius", WeatherFormatter.CelsiusUnit)]
+	[DataRow("CELSIUS", WeatherFormatter.CelsiusUnit)]
+	[DataRow("fahrenheit", WeatherFormatter.FahrenheitUnit)]
+	[DataRow("", WeatherFormatter.FahrenheitUnit)]
+	[DataRow("kelvin", WeatherFormatter.FahrenheitUnit)]
+	public void TemperatureUnit_ReturnsExpectedSuffix(string unit, string expected)
+	{
+		Assert.AreEqual(expected, WeatherFormatter.TemperatureUnit(unit));
+	}
+
+	[DataTestMethod]
+	[DataRow("kmh", "km/h")]
+	[DataRow("KMH", "km/h")]
+	[DataRow("mph", "mph")]
+	[DataRow("", "km/h")]
+	[DataRow("knots", "km/h")]
+	public void WindSpeedUnit_ReturnsExpectedLabel(string unit, string expected)
+	{
+		Assert.AreEqual(expected, WeatherFormatter.WindSpeedUnit(unit));
+	}
+
+	[TestMethod]
+	public void Temperature_Celsius_UsesCurrentCultureNumberFormat()
+	{
+		var original = CultureInfo.CurrentCulture;
+		try
+		{
+			CultureInfo.CurrentCulture = new CultureInfo("en-US");
+			Assert.AreEqual("21°C", WeatherFormatter.Temperature(21, WeatherFormatter.CelsiusKey));
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void HighLow_FormatsBothValuesWithUnit()
+	{
+		var original = CultureInfo.CurrentCulture;
+		try
+		{
+			CultureInfo.CurrentCulture = new CultureInfo("en-US");
+			Assert.AreEqual("30°F / 18°F", WeatherFormatter.HighLow(30, 18, "fahrenheit"));
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = original;
+		}
+	}
+
+	[DataTestMethod]
+	[DataRow(0, "N")]
+	[DataRow(360, "N")]
+	[DataRow(45, "NE")]
+	[DataRow(90, "E")]
+	[DataRow(135, "SE")]
+	[DataRow(180, "S")]
+	[DataRow(225, "SW")]
+	[DataRow(270, "W")]
+	[DataRow(315, "NW")]
+	[DataRow(337, "NW")]
+	[DataRow(338, "N")]
+	[DataRow(22, "N")]
+	[DataRow(23, "NE")]
+	public void CompassDirection_MapsDegreesToEightPointRose(double degrees, string expected)
+	{
+		Assert.AreEqual(expected, WeatherFormatter.CompassDirection((int)degrees));
+	}
+
+	[TestMethod]
+	public void Hour_Use24HourClock_UsesHourAndMinutePattern()
+	{
+		var original = CultureInfo.CurrentCulture;
+		try
+		{
+			CultureInfo.CurrentCulture = new CultureInfo("en-US");
+			var time = new DateTime(2024, 6, 15, 13, 30, 0);
+			Assert.AreEqual("13:30", WeatherFormatter.Hour(time, use24Hour: true));
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void Hour_Use12HourClock_UsesHourAndMeridiemPattern()
+	{
+		var original = CultureInfo.CurrentCulture;
+		try
+		{
+			CultureInfo.CurrentCulture = new CultureInfo("en-US");
+			var time = new DateTime(2024, 6, 15, 13, 30, 0);
+			Assert.AreEqual("1 PM", WeatherFormatter.Hour(time, use24Hour: false));
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void Humidity_WithValue_AppendsPercentSign()
+	{
+		var original = CultureInfo.CurrentCulture;
+		try
+		{
+			CultureInfo.CurrentCulture = new CultureInfo("en-US");
+			Assert.AreEqual("72%", WeatherFormatter.Humidity(72));
+		}
+		finally
+		{
+			CultureInfo.CurrentCulture = original;
+		}
+	}
+
+	[TestMethod]
+	public void Humidity_WithoutValue_ReturnsPlaceholder()
+	{
+		Assert.AreEqual("--", WeatherFormatter.Humidity(null));
+	}
+}

--- a/WeatherExtension/Icons.cs
+++ b/WeatherExtension/Icons.cs
@@ -72,38 +72,5 @@ internal sealed class Icons
     }
 
     internal static string GetWeatherDescription(int weatherCode)
-    {
-        return weatherCode switch
-        {
-            0 => "Clear sky",
-            1 => "Mainly clear",
-            2 => "Partly cloudy",
-            3 => "Overcast",
-            45 => "Fog",
-            48 => "Depositing rime fog",
-            51 => "Light drizzle",
-            53 => "Moderate drizzle",
-            55 => "Dense drizzle",
-            56 => "Light freezing drizzle",
-            57 => "Dense freezing drizzle",
-            61 => "Slight rain",
-            63 => "Moderate rain",
-            65 => "Heavy rain",
-            66 => "Light freezing rain",
-            67 => "Heavy freezing rain",
-            71 => "Slight snow fall",
-            73 => "Moderate snow fall",
-            75 => "Heavy snow fall",
-            77 => "Snow grains",
-            80 => "Slight rain showers",
-            81 => "Moderate rain showers",
-            82 => "Violent rain showers",
-            85 => "Slight snow showers",
-            86 => "Heavy snow showers",
-            95 => "Thunderstorm",
-            96 => "Thunderstorm with slight hail",
-            99 => "Thunderstorm with heavy hail",
-            _ => "Unknown",
-        };
-    }
+        => Microsoft.CmdPal.Ext.Weather.Services.WeatherDescriptions.GetLocalized(weatherCode);
 }

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -564,5 +564,70 @@ namespace Microsoft.CmdPal.Ext.Weather {
             }
         }
 
+        /// <summary>
+        ///   Looks up a localized string similar to Favorite.
+        /// </summary>
+        public static string favorite_tag {
+            get {
+                return ResourceManager.GetString("favorite_tag", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Loading weather….
+        /// </summary>
+        public static string dock_band_loading {
+            get {
+                return ResourceManager.GetString("dock_band_loading", resourceCulture);
+            }
+        }
+
+        public static string card_section_current {
+            get { return ResourceManager.GetString("card_section_current", resourceCulture); }
+        }
+
+        public static string card_section_next_three_hours {
+            get { return ResourceManager.GetString("card_section_next_three_hours", resourceCulture); }
+        }
+
+        public static string card_section_three_day_forecast {
+            get { return ResourceManager.GetString("card_section_three_day_forecast", resourceCulture); }
+        }
+
+        public static string card_label_high_low {
+            get { return ResourceManager.GetString("card_label_high_low", resourceCulture); }
+        }
+
+        public static string card_condition_unknown {
+            get { return ResourceManager.GetString("card_condition_unknown", resourceCulture); }
+        }
+
+        public static string weather_clear { get { return ResourceManager.GetString("weather_clear", resourceCulture); } }
+        public static string weather_mainly_clear { get { return ResourceManager.GetString("weather_mainly_clear", resourceCulture); } }
+        public static string weather_partly_cloudy { get { return ResourceManager.GetString("weather_partly_cloudy", resourceCulture); } }
+        public static string weather_overcast { get { return ResourceManager.GetString("weather_overcast", resourceCulture); } }
+        public static string weather_fog { get { return ResourceManager.GetString("weather_fog", resourceCulture); } }
+        public static string weather_drizzle { get { return ResourceManager.GetString("weather_drizzle", resourceCulture); } }
+        public static string weather_rain { get { return ResourceManager.GetString("weather_rain", resourceCulture); } }
+        public static string weather_snow { get { return ResourceManager.GetString("weather_snow", resourceCulture); } }
+        public static string weather_rain_showers { get { return ResourceManager.GetString("weather_rain_showers", resourceCulture); } }
+        public static string weather_snow_showers { get { return ResourceManager.GetString("weather_snow_showers", resourceCulture); } }
+        public static string weather_thunderstorm { get { return ResourceManager.GetString("weather_thunderstorm", resourceCulture); } }
+        public static string feels_like_template { get { return ResourceManager.GetString("feels_like_template", resourceCulture); } }
+        public static string search_hint_examples_title { get { return ResourceManager.GetString("search_hint_examples_title", resourceCulture); } }
+        public static string search_hint_examples_block { get { return ResourceManager.GetString("search_hint_examples_block", resourceCulture); } }
+        public static string search_hint_favorite_shortcut { get { return ResourceManager.GetString("search_hint_favorite_shortcut", resourceCulture); } }
+        public static string search_hint_multiple_favorites { get { return ResourceManager.GetString("search_hint_multiple_favorites", resourceCulture); } }
+        public static string page_forecast_title { get { return ResourceManager.GetString("page_forecast_title", resourceCulture); } }
+        public static string page_hourly_title { get { return ResourceManager.GetString("page_hourly_title", resourceCulture); } }
+        public static string card_section_next_hours { get { return ResourceManager.GetString("card_section_next_hours", resourceCulture); } }
+        public static string card_section_day_forecast { get { return ResourceManager.GetString("card_section_day_forecast", resourceCulture); } }
+        public static string settings_page_title { get { return ResourceManager.GetString("settings_page_title", resourceCulture); } }
+        public static string hour_format_title { get { return ResourceManager.GetString("hour_format_title", resourceCulture); } }
+        public static string hour_format_description { get { return ResourceManager.GetString("hour_format_description", resourceCulture); } }
+        public static string hour_format_12 { get { return ResourceManager.GetString("hour_format_12", resourceCulture); } }
+        public static string hour_format_24 { get { return ResourceManager.GetString("hour_format_24", resourceCulture); } }
+        public static string settings_save_button { get { return ResourceManager.GetString("settings_save_button", resourceCulture); } }
+
     }
 }

--- a/WeatherExtension/Properties/Resources.resx
+++ b/WeatherExtension/Properties/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -288,4 +288,87 @@ If you continue to have issues, please [file a bug](https://github.com/michaeljo
   <data name="no_favorites_hint" xml:space="preserve">
     <value>Search for a location and add it to your favorites</value>
   </data>
-</root>
+  
+  <data name="favorite_tag" xml:space="preserve">
+    <value>Favorite</value>
+    <comment>Tag shown on list items whose location is in favorites</comment>
+  </data>
+  <data name="dock_band_loading" xml:space="preserve">
+    <value>Loading weather…</value>
+    <comment>Initial title shown on a pinned dock band before its weather has loaded</comment>
+  </data>
+  <data name="card_section_current" xml:space="preserve">
+    <value>Current</value>
+  </data>
+  <data name="card_section_next_three_hours" xml:space="preserve">
+    <value>Next Three Hours</value>
+  </data>
+  <data name="card_section_three_day_forecast" xml:space="preserve">
+    <value>3-Day Forecast</value>
+  </data>
+  <data name="card_label_high_low" xml:space="preserve">
+    <value>High / Low</value>
+  </data>
+  <data name="card_condition_unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="weather_clear" xml:space="preserve"><value>Clear sky</value></data>
+  <data name="weather_mainly_clear" xml:space="preserve"><value>Mainly clear</value></data>
+  <data name="weather_partly_cloudy" xml:space="preserve"><value>Partly cloudy</value></data>
+  <data name="weather_overcast" xml:space="preserve"><value>Overcast</value></data>
+  <data name="weather_fog" xml:space="preserve"><value>Fog</value></data>
+  <data name="weather_drizzle" xml:space="preserve"><value>Drizzle</value></data>
+  <data name="weather_rain" xml:space="preserve"><value>Rain</value></data>
+  <data name="weather_snow" xml:space="preserve"><value>Snow</value></data>
+  <data name="weather_rain_showers" xml:space="preserve"><value>Rain showers</value></data>
+  <data name="weather_snow_showers" xml:space="preserve"><value>Snow showers</value></data>
+  <data name="weather_thunderstorm" xml:space="preserve"><value>Thunderstorm</value></data>
+  <data name="feels_like_template" xml:space="preserve">
+    <value>{0} — {1} (feels like {2})</value>
+    <comment>{0}=condition, {1}=temperature, {2}=apparent temperature. Used as the subtitle on weather list items.</comment>
+  </data>
+  
+  
+  
+  
+  <data name="page_forecast_title" xml:space="preserve">
+    <value>Forecast</value>
+  </data>
+  <data name="page_hourly_title" xml:space="preserve">
+    <value>Hourly Forecast</value>
+  </data>
+  <data name="card_section_next_hours" xml:space="preserve">
+    <value>Next {0} Hours</value>
+    <comment>Section header on the dock band card. {0} is the number of hours.</comment>
+  </data>
+  <data name="card_section_day_forecast" xml:space="preserve">
+    <value>{0}-Day Forecast</value>
+    <comment>Section header on the dock band card. {0} is the number of days.</comment>
+  </data>
+  
+  
+  <data name="settings_page_title" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="hour_format_title" xml:space="preserve">
+    <value>Time Format</value>
+  </data>
+  <data name="hour_format_description" xml:space="preserve">
+    <value>Choose between 12-hour and 24-hour clock display.</value>
+  </data>
+  <data name="hour_format_12" xml:space="preserve">
+    <value>12-hour (AM/PM)</value>
+  </data>
+  <data name="hour_format_24" xml:space="preserve">
+    <value>24-hour</value>
+  </data>
+  <data name="settings_save_button" xml:space="preserve">
+    <value>Save</value>
+    <comment>Label on the Save button at the bottom of the settings sheet.</comment>
+  </data>
+  
+  
+<data name="search_hint_examples_title" xml:space="preserve"><value>Examples:</value></data><data name="search_hint_examples_block" xml:space="preserve"><value>London
+Paris, FR
+90210
+Berlin, Germany</value></data><data name="search_hint_favorite_shortcut" xml:space="preserve"><value>Press Ctrl+D to add a location to your favorites and the dock.</value></data><data name="search_hint_multiple_favorites" xml:space="preserve"><value>With multiple favorites, the expanded card uses your first favorite by default. Add a second (or more) location to the dock anytime from Command Palette dock customization.</value></data></root>

--- a/WeatherExtension/Services/WeatherDescriptions.cs
+++ b/WeatherExtension/Services/WeatherDescriptions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using BaldBeardedBuilder.WeatherExtension;
+
+namespace Microsoft.CmdPal.Ext.Weather.Services;
+
+/// <summary>
+/// Looks up a localized human-readable description for a WMO weather code.
+/// The full set of WMO codes (~28) is mapped onto a smaller set of broad
+/// categories so we don't have to ship dozens of translated strings per
+/// language. The icon already conveys intensity, so this stays light.
+/// </summary>
+internal static class WeatherDescriptions
+{
+	public static string GetLocalized(int weatherCode)
+	{
+		var key = weatherCode switch
+		{
+			0 => "weather_clear",
+			1 => "weather_mainly_clear",
+			2 => "weather_partly_cloudy",
+			3 => "weather_overcast",
+			45 or 48 => "weather_fog",
+			51 or 53 or 55 or 56 or 57 => "weather_drizzle",
+			61 or 63 or 65 or 66 or 67 => "weather_rain",
+			71 or 73 or 75 or 77 => "weather_snow",
+			80 or 81 or 82 => "weather_rain_showers",
+			85 or 86 => "weather_snow_showers",
+			95 or 96 or 99 => "weather_thunderstorm",
+			_ => null,
+		};
+
+		if (key == null)
+		{
+			return Resources.card_condition_unknown;
+		}
+
+		// Pass CurrentUICulture explicitly so the analyzer is happy and the
+		// behavior is unambiguous: we honor the user's UI language with the
+		// neutral resx as fallback.
+		return Resources.ResourceManager.GetString(key, CultureInfo.CurrentUICulture)
+			?? Resources.card_condition_unknown;
+	}
+}

--- a/WeatherExtension/Services/WeatherFormatter.cs
+++ b/WeatherExtension/Services/WeatherFormatter.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+
+namespace Microsoft.CmdPal.Ext.Weather.Services;
+/// <summary>
+/// Centralizes how weather values are turned into display strings.
+/// Pages, dock bands and adaptive cards used to format temperatures,
+/// humidity and wind inline, which made unit changes and culture fixes
+/// require touch-ups in many places. Funnel them through here instead.
+/// </summary>
+internal static class WeatherFormatter
+{
+	public const string CelsiusUnit = "\u00B0C";
+	public const string FahrenheitUnit = "\u00B0F";
+	public const string CelsiusKey = "celsius";
+	public const string KilometersPerHourKey = "kmh";
+	public const string MilesPerHourKey = "mph";
+
+	// CA1863: cache the composite format for the localized "feels like" string.
+	// The template comes from Resources, so it varies per culture; CurrentSubtitle
+	// rebuilds the cache when the culture changes.
+	private static System.Text.CompositeFormat? _feelsLikeFormat;
+	private static string? _feelsLikeFormatCulture;
+	private static readonly Lock _feelsLikeSync = new();
+
+	private static System.Text.CompositeFormat GetFeelsLikeFormat()
+	{
+		var current = CultureInfo.CurrentUICulture.Name;
+		lock (_feelsLikeSync)
+		{
+			if (_feelsLikeFormat != null && _feelsLikeFormatCulture == current)
+			{
+				return _feelsLikeFormat;
+			}
+
+			_feelsLikeFormat = System.Text.CompositeFormat.Parse(Resources.feels_like_template);
+			_feelsLikeFormatCulture = current;
+			return _feelsLikeFormat;
+		}
+	}
+
+	public static string TemperatureUnit(string temperatureUnit)
+		=> string.Equals(temperatureUnit, CelsiusKey, StringComparison.OrdinalIgnoreCase)
+			? CelsiusUnit
+			: FahrenheitUnit;
+
+	public static string WindSpeedUnit(string windSpeedUnit)
+		=> string.Equals(windSpeedUnit, MilesPerHourKey, StringComparison.OrdinalIgnoreCase)
+			? "mph"
+			: "km/h";
+
+	public static string Temperature(double value, string temperatureUnit, int decimals = 0)
+	{
+		var format = decimals <= 0 ? "F0" : $"F{decimals}";
+		return string.Create(
+			CultureInfo.CurrentCulture,
+			$"{value.ToString(format, CultureInfo.CurrentCulture)}{TemperatureUnit(temperatureUnit)}");
+	}
+
+	public static string FeelsLike(double value, string temperatureUnit, int decimals = 0)
+		=> Temperature(value, temperatureUnit, decimals);
+
+	public static string HighLow(double high, double low, string temperatureUnit)
+		=> string.Format(
+			CultureInfo.CurrentCulture,
+			"{0} / {1}",
+			Temperature(high, temperatureUnit),
+			Temperature(low, temperatureUnit));
+
+	public static string Humidity(int? value)
+		=> value.HasValue
+			? string.Format(CultureInfo.CurrentCulture, "{0}%", value.Value)
+			: "--";
+
+	public static string Wind(double speed, string windSpeedUnit, int decimals = 1)
+	{
+		var format = decimals <= 0 ? "F0" : $"F{decimals}";
+		return string.Format(
+			CultureInfo.CurrentCulture,
+			"{0} {1}",
+			speed.ToString(format, CultureInfo.CurrentCulture),
+			WindSpeedUnit(windSpeedUnit));
+	}
+
+	public static string PrecipitationProbability(int? probability)
+		=> string.Format(CultureInfo.CurrentCulture, "{0}%", probability ?? 0);
+
+	public static string ConditionWithTemperature(int weatherCode, double temperature, string temperatureUnit)
+		=> string.Format(
+			CultureInfo.CurrentCulture,
+			"{0} \u2014 {1}",
+			WeatherDescriptions.GetLocalized(weatherCode),
+			Temperature(temperature, temperatureUnit));
+
+	public static string CurrentSubtitle(CurrentWeather current, string temperatureUnit)
+		=> string.Format(
+			CultureInfo.CurrentCulture,
+			GetFeelsLikeFormat(),
+			WeatherDescriptions.GetLocalized(current.WeatherCode),
+			Temperature(current.Temperature, temperatureUnit),
+			Temperature(current.ApparentTemperature, temperatureUnit));
+
+	public static string CompassDirection(int degrees)
+	{
+		// 8-point compass: round to nearest 45° wedge.
+		var directions = new[] { "N", "NE", "E", "SE", "S", "SW", "W", "NW" };
+		var index = ((int)Math.Round(degrees / 45.0) % 8 + 8) % 8;
+		return directions[index];
+	}
+
+	/// <summary>
+	/// Formats a hour-of-day for display, honoring the user's 12/24-hour
+	/// preference. The 24-hour format uses the locale's pattern so e.g.
+	/// Japanese gets "13時" while English gets "13:00".
+	/// </summary>
+	public static string Hour(DateTime time, bool use24Hour)
+	{
+		return time.ToString(
+			use24Hour ? "HH:mm" : "h tt",
+			CultureInfo.CurrentCulture);
+	}
+}


### PR DESCRIPTION
## Summary
Centralize WMO descriptions and display formatting + unit tests.

## Merge order
**Merge #106 (i18n) first** for satellite \weather_*\ strings in all 14 cultures. This PR includes en-US \Resources.resx\ keys only.

## Test plan
- [x] WeatherFormatterTests, WeatherDescriptionsTests, IconsTests (category mapping)
- [x] CI fix: IconsTests updated for grouped WMO categories (not per-code strings)