### PR TITLE
feat: rolling file logger and Submit a Bug command

### DIFF
--- a/WeatherExtension.Tests/RollingFileLoggerTests.cs
+++ b/WeatherExtension.Tests/RollingFileLoggerTests.cs
@@ -5,7 +5,6 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using BaldBeardedBuilder.WeatherExtension;
-using BaldBeardedBuilder.WeatherExtension;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/RollingFileLoggerTests.cs
+++ b/WeatherExtension.Tests/RollingFileLoggerTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="RollingFileLogger"/>.
+///
+/// The singleton writes to <c>AppContext.BaseDirectory/Logs/</c>, which in
+/// the test runner resolves to the test output directory. Each test flushes
+/// the logger before and after to close the file handle, ensuring reads and
+/// cleanups are not blocked by an open <see cref="FileStream"/>.
+/// </summary>
+[TestClass]
+public class RollingFileLoggerTests
+{
+	private string _logDirectory = string.Empty;
+
+	[TestInitialize]
+	public void Setup()
+	{
+		// Flush any writer the previous test may have left open.
+		RollingFileLogger.Instance.Flush();
+		_logDirectory = RollingFileLogger.Instance.LogDirectory;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		// Close the writer so the test runner can clean up the output directory.
+		RollingFileLogger.Instance.Flush();
+	}
+
+	// ---------------------------------------------------------------
+	// Log() — file creation
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void Log_Info_CreatesFileInLogDirectory()
+	{
+		RollingFileLogger.Instance.Log(LogLevel.Info, "RollingFileLoggerTests: file creation check");
+		RollingFileLogger.Instance.Flush();
+
+		var files = Directory.GetFiles(_logDirectory, "weather-*.log");
+		Assert.IsTrue(files.Length > 0, "Expected at least one log file in the log directory after writing.");
+	}
+
+	[TestMethod]
+	public void Log_CreatesDirectoryIfMissing()
+	{
+		// The logger creates the directory on first write. Because the
+		// singleton may have already created it, we verify it exists rather
+		// than deleting it (which would affect shared singleton state).
+		RollingFileLogger.Instance.Log(LogLevel.Info, "RollingFileLoggerTests: directory creation check");
+		RollingFileLogger.Instance.Flush();
+
+		Assert.IsTrue(Directory.Exists(_logDirectory),
+			$"Log directory should exist after writing: {_logDirectory}");
+	}
+
+	// ---------------------------------------------------------------
+	// Log() — entry format
+	// ---------------------------------------------------------------
+
+	[DataTestMethod]
+	[DataRow(LogLevel.Debug, "DEBUG")]
+	[DataRow(LogLevel.Info, "INFO")]
+	[DataRow(LogLevel.Warning, "WARN")]
+	[DataRow(LogLevel.Error, "ERROR")]
+	public void Log_EntryFormat_ContainsTimestampLevelAndMessage(LogLevel level, string expectedTag)
+	{
+		var marker = $"format-check-{Guid.NewGuid()}";
+
+		RollingFileLogger.Instance.Log(level, marker);
+		RollingFileLogger.Instance.Flush();
+
+		var logFile = LatestLogFile();
+		Assert.IsNotNull(logFile, "No log file found after writing.");
+
+		var content = File.ReadAllText(logFile!);
+		Assert.IsTrue(content.Contains(marker, StringComparison.Ordinal),
+			$"Log entry must contain the original message. Content:\n{content}");
+		Assert.IsTrue(content.Contains($"[{expectedTag}]", StringComparison.Ordinal),
+			$"Log entry must contain [{expectedTag}] level tag. Content:\n{content}");
+
+		// Verify ISO-8601 timestamp pattern: [yyyy-MM-ddTHH:mm:ss.fffZ]
+		Assert.IsTrue(
+			Regex.IsMatch(content, @"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]"),
+			$"Log entry must contain an ISO-8601 timestamp. Content:\n{content}");
+	}
+
+	[TestMethod]
+	public void Log_WithException_AppendsSeparateExceptionLine()
+	{
+		var marker = $"exception-check-{Guid.NewGuid()}";
+		var ex = new InvalidOperationException("test-exception-message");
+
+		RollingFileLogger.Instance.Log(LogLevel.Error, marker, ex);
+		RollingFileLogger.Instance.Flush();
+
+		var logFile = LatestLogFile();
+		Assert.IsNotNull(logFile, "No log file found after writing.");
+
+		var content = File.ReadAllText(logFile!);
+		Assert.IsTrue(content.Contains("test-exception-message", StringComparison.Ordinal),
+			"Log file should contain the exception message.");
+		Assert.IsTrue(content.Contains(nameof(InvalidOperationException), StringComparison.Ordinal),
+			"Log file should contain the exception type name.");
+	}
+
+	// ---------------------------------------------------------------
+	// Flush() — releases the file handle
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void Flush_AllowsFileToBeReadWithoutLock()
+	{
+		RollingFileLogger.Instance.Log(LogLevel.Info, $"flush-test-{Guid.NewGuid()}");
+		RollingFileLogger.Instance.Flush();
+
+		var logFile = LatestLogFile();
+		Assert.IsNotNull(logFile, "No log file found after writing.");
+
+		// After Flush(), the writer is closed. We should be able to open
+		// the file with exclusive access (simulating what ZipFile does).
+		using var fs = new FileStream(logFile!, FileMode.Open, FileAccess.Read, FileShare.None);
+		Assert.IsTrue(fs.Length > 0, "Log file should be non-empty after writing.");
+	}
+
+	[TestMethod]
+	public void Log_AfterFlush_ReopensAndContinuesWriting()
+	{
+		var marker1 = $"before-flush-{Guid.NewGuid()}";
+		var marker2 = $"after-flush-{Guid.NewGuid()}";
+
+		RollingFileLogger.Instance.Log(LogLevel.Info, marker1);
+		RollingFileLogger.Instance.Flush();
+
+		// Log again after Flush() — the logger must reopen the file.
+		RollingFileLogger.Instance.Log(LogLevel.Info, marker2);
+		RollingFileLogger.Instance.Flush();
+
+		var logFile = LatestLogFile();
+		Assert.IsNotNull(logFile, "No log file found.");
+
+		var content = File.ReadAllText(logFile!);
+		Assert.IsTrue(content.Contains(marker1, StringComparison.Ordinal),
+			"Entry written before Flush() must be present.");
+		Assert.IsTrue(content.Contains(marker2, StringComparison.Ordinal),
+			"Entry written after Flush() must also be present — logger must reopen the file.");
+	}
+
+	// ---------------------------------------------------------------
+	// Concurrent writes — no exceptions or torn entries
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void Log_ConcurrentWrites_DoNotThrow()
+	{
+		const int threadCount = 20;
+		const int writesPerThread = 50;
+		var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+		Parallel.For(0, threadCount, i =>
+		{
+			for (var j = 0; j < writesPerThread; j++)
+			{
+				try
+				{
+					RollingFileLogger.Instance.Log(LogLevel.Debug,
+						$"concurrent-{i}-{j}-{Guid.NewGuid()}");
+				}
+				catch (Exception ex)
+				{
+					exceptions.Add(ex);
+				}
+			}
+		});
+
+		RollingFileLogger.Instance.Flush();
+
+		Assert.AreEqual(0, exceptions.Count,
+			$"No exceptions should be thrown during concurrent writes. Got: {string.Join(", ", exceptions.Select(e => e.Message))}");
+	}
+
+	[TestMethod]
+	public void Log_ConcurrentWrites_AllEntriesPresent()
+	{
+		const int entryCount = 100;
+		var markers = Enumerable.Range(0, entryCount)
+			.Select(_ => Guid.NewGuid().ToString("N"))
+			.ToArray();
+
+		Parallel.ForEach(markers, marker =>
+			RollingFileLogger.Instance.Log(LogLevel.Info, $"concurrent-marker-{marker}"));
+
+		RollingFileLogger.Instance.Flush();
+
+		var logFile = LatestLogFile();
+		Assert.IsNotNull(logFile, "No log file found.");
+
+		var content = File.ReadAllText(logFile!);
+		var missing = markers.Where(m => !content.Contains(m, StringComparison.Ordinal)).ToList();
+
+		Assert.AreEqual(0, missing.Count,
+			$"All {entryCount} markers must be present in the log. Missing: {string.Join(", ", missing.Take(5))}");
+	}
+
+	// ---------------------------------------------------------------
+	// LogDirectory property
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void LogDirectory_EndsWithLogsSegment()
+	{
+		var dir = RollingFileLogger.Instance.LogDirectory;
+
+		Assert.IsTrue(
+			dir.EndsWith("Logs", StringComparison.OrdinalIgnoreCase) ||
+			dir.EndsWith("Logs" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase),
+			$"LogDirectory should end with 'Logs'. Got: {dir}");
+	}
+
+	// ---------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------
+
+	/// <summary>Returns the most-recently-modified weather log file, or null.</summary>
+	private string? LatestLogFile()
+	{
+		if (!Directory.Exists(_logDirectory))
+		{
+			return null;
+		}
+
+		return Directory
+			.GetFiles(_logDirectory, "weather-*.log")
+			.OrderByDescending(File.GetLastWriteTimeUtc)
+			.FirstOrDefault();
+	}
+}

--- a/WeatherExtension.Tests/RollingFileLoggerTests.cs
+++ b/WeatherExtension.Tests/RollingFileLoggerTests.cs
@@ -68,12 +68,14 @@ public class RollingFileLoggerTests
 	// ---------------------------------------------------------------
 
 	[DataTestMethod]
-	[DataRow(LogLevel.Debug, "DEBUG")]
-	[DataRow(LogLevel.Info, "INFO")]
-	[DataRow(LogLevel.Warning, "WARN")]
-	[DataRow(LogLevel.Error, "ERROR")]
-	public void Log_EntryFormat_ContainsTimestampLevelAndMessage(LogLevel level, string expectedTag)
+	[DataRow(0, "DEBUG")]  // LogLevel.Debug
+	[DataRow(1, "INFO")]   // LogLevel.Info
+	[DataRow(2, "WARN")]   // LogLevel.Warning
+	[DataRow(3, "ERROR")]  // LogLevel.Error
+	public void Log_EntryFormat_ContainsTimestampLevelAndMessage(int levelInt, string expectedTag)
 	{
+		// LogLevel is internal; use int parameter to avoid CS0051 accessibility mismatch.
+		var level = (LogLevel)levelInt;
 		var marker = $"format-check-{Guid.NewGuid()}";
 
 		RollingFileLogger.Instance.Log(level, marker);

--- a/WeatherExtension.Tests/RollingFileLoggerTests.cs
+++ b/WeatherExtension.Tests/RollingFileLoggerTests.cs
@@ -4,6 +4,8 @@
 
 using System.IO;
 using System.Text.RegularExpressions;
+using BaldBeardedBuilder.WeatherExtension;
+using BaldBeardedBuilder.WeatherExtension;
 
 namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 

--- a/WeatherExtension.Tests/SubmitBugPageTests.cs
+++ b/WeatherExtension.Tests/SubmitBugPageTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Pages;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="SubmitBugPage"/>.
+/// Verifies metadata, item count, and that each item carries a Details panel.
+/// Follows the same pattern as <see cref="EmptySearchHintPageTests"/>.
+/// </summary>
+[TestClass]
+public class SubmitBugPageTests
+{
+	// ---------------------------------------------------------------
+	// Metadata
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void Name_IsBugReportTitle()
+	{
+		var page = new SubmitBugPage();
+
+		Assert.AreEqual(Resources.bug_report_title, page.Name);
+	}
+
+	[TestMethod]
+	public void Title_IsBugReportTitle()
+	{
+		var page = new SubmitBugPage();
+
+		Assert.AreEqual(Resources.bug_report_title, page.Title);
+	}
+
+	[TestMethod]
+	public void Icon_IsNotNull()
+	{
+		var page = new SubmitBugPage();
+
+		Assert.IsNotNull(page.Icon);
+	}
+
+	[TestMethod]
+	public void Id_IsNotNullOrEmpty()
+	{
+		var page = new SubmitBugPage();
+
+		Assert.IsFalse(string.IsNullOrWhiteSpace(page.Id),
+			"Page Id must be set so CmdPal can uniquely identify the page.");
+	}
+
+	[TestMethod]
+	public void ShowDetails_IsTrue()
+	{
+		var page = new SubmitBugPage();
+
+		Assert.IsTrue(page.ShowDetails,
+			"ShowDetails must be true so the instructions Details panel is visible.");
+	}
+
+	// ---------------------------------------------------------------
+	// GetItems() — count and structure
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void GetItems_ReturnsExactlyTwoItems()
+	{
+		var page = new SubmitBugPage();
+
+		var items = page.GetItems();
+
+		Assert.AreEqual(2, items.Length,
+			"SubmitBugPage must return exactly 2 items: Save Logs and Open GitHub Issues.");
+	}
+
+	[TestMethod]
+	public void GetItems_FirstItem_HasSaveLogsTitle()
+	{
+		var page = new SubmitBugPage();
+
+		var firstItem = (ListItem)page.GetItems()[0];
+
+		Assert.AreEqual(Resources.bug_report_save_logs, firstItem.Title,
+			"First item must be the Save Logs action.");
+	}
+
+	[TestMethod]
+	public void GetItems_SecondItem_HasOpenGitHubTitle()
+	{
+		var page = new SubmitBugPage();
+
+		var secondItem = (ListItem)page.GetItems()[1];
+
+		Assert.AreEqual(Resources.bug_report_open_github, secondItem.Title,
+			"Second item must be the Open GitHub Issues action.");
+	}
+
+	[TestMethod]
+	public void GetItems_BothItems_HaveDetailsPanel()
+	{
+		var page = new SubmitBugPage();
+
+		var items = page.GetItems();
+
+		foreach (var item in items.Cast<ListItem>())
+		{
+			Assert.IsNotNull(item.Details,
+				$"Item '{item.Title}' must have a Details panel with instructions.");
+		}
+	}
+
+	[TestMethod]
+	public void GetItems_DetailsPanel_HasNonEmptyBody()
+	{
+		var page = new SubmitBugPage();
+
+		var firstItem = (ListItem)page.GetItems()[0];
+		var details = (Details)firstItem.Details!;
+
+		Assert.IsFalse(string.IsNullOrWhiteSpace(details.Body),
+			"Details.Body must contain the bug report instructions and not be empty.");
+	}
+
+	[TestMethod]
+	public void GetItems_DetailsPanel_TitleIsBugReportTitle()
+	{
+		var page = new SubmitBugPage();
+
+		var firstItem = (ListItem)page.GetItems()[0];
+		var details = (Details)firstItem.Details!;
+
+		Assert.AreEqual(Resources.bug_report_title, details.Title,
+			"Details.Title must match the page title for consistent header display.");
+	}
+
+	// ---------------------------------------------------------------
+	// Stability
+	// ---------------------------------------------------------------
+
+	[TestMethod]
+	public void GetItems_CalledTwice_ReturnsSameInstances()
+	{
+		var page = new SubmitBugPage();
+
+		var items1 = page.GetItems();
+		var items2 = page.GetItems();
+
+		Assert.AreSame(items1[0], items2[0],
+			"GetItems() should return the same pre-built array — no allocation on repeat calls.");
+		Assert.AreSame(items1[1], items2[1],
+			"GetItems() should return the same pre-built array — no allocation on repeat calls.");
+	}
+}

--- a/WeatherExtension/Commands/OpenGitHubIssuesCommand.cs
+++ b/WeatherExtension/Commands/OpenGitHubIssuesCommand.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.System;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class OpenGitHubIssuesCommand : InvokableCommand
+{
+    private const string GitHubIssuesUrl = "https://github.com/michaeljolley/WeatherExtension/issues/new";
+
+    public OpenGitHubIssuesCommand()
+    {
+        Name = Resources.bug_report_open_github;
+        Icon = new IconInfo("\uE8A7"); // Link icon
+    }
+
+    public override ICommandResult Invoke()
+    {
+        try
+        {
+            _ = Launcher.LaunchUriAsync(new Uri(GitHubIssuesUrl));
+        }
+        catch (Exception ex)
+        {
+            WeatherLogger.LogToHost(MessageState.Error, $"OpenGitHubIssuesCommand failed: {ex.Message}");
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/WeatherExtension/Commands/SaveLogsCommand.cs
+++ b/WeatherExtension/Commands/SaveLogsCommand.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Compression;
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class SaveLogsCommand : InvokableCommand
+{
+    public SaveLogsCommand()
+    {
+        Name = Resources.bug_report_save_logs;
+        Icon = new IconInfo("\uE74E"); // Save icon
+    }
+
+    public override ICommandResult Invoke()
+    {
+        try
+        {
+            RollingFileLogger.Instance.Flush();
+
+            var logDir = RollingFileLogger.Instance.LogDirectory;
+            var desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            var zipName = $"WeatherExtension-Logs-{DateTime.Now:yyyy-MM-dd}.zip";
+            var zipPath = Path.Combine(desktop, zipName);
+
+            // Remove any existing zip with the same name so CreateFromDirectory doesn't throw.
+            if (File.Exists(zipPath))
+            {
+                File.Delete(zipPath);
+            }
+
+            // Add only *.log files — skip any unrelated files that may be in the directory.
+            if (Directory.Exists(logDir))
+            {
+                using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+                foreach (var logFile in Directory.EnumerateFiles(logDir, "*.log"))
+                {
+                    archive.CreateEntryFromFile(logFile, Path.GetFileName(logFile), CompressionLevel.Optimal);
+                }
+            }
+
+            WeatherLogger.LogToHost(MessageState.Info, $"Logs saved to: {zipPath}");
+        }
+        catch (Exception ex)
+        {
+            WeatherLogger.LogToHost(MessageState.Error, $"SaveLogsCommand failed: {ex.Message}");
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/WeatherExtension/Pages/SubmitBugPage.cs
+++ b/WeatherExtension/Pages/SubmitBugPage.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Commands;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Pages;
+
+/// <summary>
+/// Guides the user through submitting a bug report.
+/// Displays two actions — save logs to Desktop and open GitHub Issues —
+/// with step-by-step instructions in the Details panel.
+/// </summary>
+internal sealed partial class SubmitBugPage : DynamicListPage
+{
+    private readonly IListItem[] _items;
+
+    public SubmitBugPage()
+    {
+        Name = Resources.bug_report_title;
+        Title = Resources.bug_report_title;
+        Icon = new IconInfo("\uE730"); // Bug icon
+        Id = "com.baldbeardedbuilder.cmdpal.weather.submitbug";
+        ShowDetails = true;
+
+        var instructionDetails = new Details
+        {
+            Title = Resources.bug_report_title,
+            Body = Resources.bug_report_instructions,
+        };
+
+        _items =
+        [
+            new ListItem(new SaveLogsCommand())
+            {
+                Title = Resources.bug_report_save_logs,
+                Subtitle = Resources.bug_report_title,
+                Details = instructionDetails,
+            },
+            new ListItem(new OpenGitHubIssuesCommand())
+            {
+                Title = Resources.bug_report_open_github,
+                Subtitle = Resources.bug_report_title,
+                Details = instructionDetails,
+            },
+        ];
+    }
+
+    public override IListItem[] GetItems() => _items;
+}

--- a/WeatherExtension/Pages/SubmitBugPage.cs
+++ b/WeatherExtension/Pages/SubmitBugPage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CmdPal.Ext.Weather.Pages;
 /// Displays two actions — save logs to Desktop and open GitHub Issues —
 /// with step-by-step instructions in the Details panel.
 /// </summary>
-internal sealed partial class SubmitBugPage : DynamicListPage
+internal sealed partial class SubmitBugPage : ListPage
 {
     private readonly IListItem[] _items;
 

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -641,5 +641,11 @@ namespace Microsoft.CmdPal.Ext.Weather {
         public static string compass_w { get { return ResourceManager.GetString("compass_w", resourceCulture); } }
         public static string compass_nw { get { return ResourceManager.GetString("compass_nw", resourceCulture); } }
 
+        public static string bug_report_title { get { return ResourceManager.GetString("bug_report_title", resourceCulture); } }
+        public static string bug_report_save_logs { get { return ResourceManager.GetString("bug_report_save_logs", resourceCulture); } }
+        public static string bug_report_open_github { get { return ResourceManager.GetString("bug_report_open_github", resourceCulture); } }
+        public static string bug_report_instructions { get { return ResourceManager.GetString("bug_report_instructions", resourceCulture); } }
+        public static string bug_report_logs_saved { get { return ResourceManager.GetString("bug_report_logs_saved", resourceCulture); } }
+
     }
 }

--- a/WeatherExtension/Properties/Resources.resx
+++ b/WeatherExtension/Properties/Resources.resx
@@ -384,4 +384,16 @@ Berlin, Germany</value></data><data name="search_hint_favorite_shortcut" xml:spa
   <data name="compass_sw" xml:space="preserve"><value>SW</value></data>
   <data name="compass_w" xml:space="preserve"><value>W</value></data>
   <data name="compass_nw" xml:space="preserve"><value>NW</value></data>
+  <data name="bug_report_title" xml:space="preserve"><value>Submit a Bug Report</value></data>
+  <data name="bug_report_save_logs" xml:space="preserve"><value>Save Logs to Desktop</value></data>
+  <data name="bug_report_open_github" xml:space="preserve"><value>Open GitHub Issues</value></data>
+  <data name="bug_report_instructions" xml:space="preserve"><value>## How to report a bug
+
+1. Click **Save Logs to Desktop** below to collect diagnostic logs
+2. Click **Open GitHub Issues** to create a new issue
+3. Describe the problem you encountered
+4. Drag and drop the log zip file into the issue body
+
+The zip file will be saved to your Desktop.</value></data>
+  <data name="bug_report_logs_saved" xml:space="preserve"><value>Logs saved to Desktop</value></data>
 </root>

--- a/WeatherExtension/Services/RollingFileLogger.cs
+++ b/WeatherExtension/Services/RollingFileLogger.cs
@@ -18,7 +18,7 @@ internal enum LogLevel
 /// Thread-safe rolling file logger. One file per day, 7-day retention,
 /// 5 MB cap per file. Zero external dependencies — AOT-safe System.IO only.
 /// </summary>
-internal sealed class RollingFileLogger : IDisposable
+internal sealed partial class RollingFileLogger : IDisposable
 {
 	private const int MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
 	private const int RetentionDays = 7;

--- a/WeatherExtension/Services/RollingFileLogger.cs
+++ b/WeatherExtension/Services/RollingFileLogger.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace BaldBeardedBuilder.WeatherExtension;
+
+internal enum LogLevel
+{
+	Debug,
+	Info,
+	Warning,
+	Error,
+}
+
+/// <summary>
+/// Thread-safe rolling file logger. One file per day, 7-day retention,
+/// 5 MB cap per file. Zero external dependencies — AOT-safe System.IO only.
+/// </summary>
+internal sealed class RollingFileLogger
+{
+	private const int MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
+	private const int RetentionDays = 7;
+
+	private static readonly Lazy<RollingFileLogger> _instance =
+		new(() => new RollingFileLogger(), isThreadSafe: true);
+
+	public static RollingFileLogger Instance => _instance.Value;
+
+	private readonly Lock _sync = new();
+	private readonly string _logDirectory;
+
+	private StreamWriter? _writer;
+	private string _currentLogPath = string.Empty;
+	private DateOnly _currentDate;
+
+	public string LogDirectory => _logDirectory;
+
+	private RollingFileLogger()
+	{
+		_logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+	}
+
+	public void Log(LogLevel level, string message)
+	{
+		var entry = FormatEntry(level, message, exception: null);
+		WriteEntry(entry);
+	}
+
+	public void Log(LogLevel level, string message, Exception ex)
+	{
+		var entry = FormatEntry(level, message, ex);
+		WriteEntry(entry);
+	}
+
+	/// <summary>
+	/// Flushes and closes the current file handle so callers can safely
+	/// zip the log directory. The next <see cref="Log"/> call reopens the file.
+	/// </summary>
+	public void Flush()
+	{
+		lock (_sync)
+		{
+			CloseWriter();
+		}
+	}
+
+	private static string FormatEntry(LogLevel level, string message, Exception? exception)
+	{
+		var levelTag = level switch
+		{
+			LogLevel.Debug => "DEBUG",
+			LogLevel.Warning => "WARN",
+			LogLevel.Error => "ERROR",
+			_ => "INFO",
+		};
+
+		var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture);
+		var line = $"[{timestamp}] [{levelTag}] {message}";
+
+		if (exception != null)
+		{
+			line = line + Environment.NewLine + "  " + exception.ToString().Replace(Environment.NewLine, Environment.NewLine + "  ", StringComparison.Ordinal);
+		}
+
+		return line;
+	}
+
+	private void WriteEntry(string entry)
+	{
+		try
+		{
+			lock (_sync)
+			{
+				var today = DateOnly.FromDateTime(DateTime.UtcNow);
+				EnsureWriter(today);
+				_writer?.WriteLine(entry);
+				_writer?.Flush();
+			}
+		}
+		catch
+		{
+			// Logger failures must never crash the extension.
+		}
+	}
+
+	private void EnsureWriter(DateOnly today)
+	{
+		// Day rolled — close current writer and clean up old files.
+		if (_writer != null && today != _currentDate)
+		{
+			CloseWriter();
+			DeleteOldLogs(today);
+		}
+
+		if (_writer != null)
+		{
+			// Still on the same day — check size cap.
+			if (ExceedsSizeCap(_currentLogPath))
+			{
+				CloseWriter();
+			}
+			else
+			{
+				return;
+			}
+		}
+
+		// Writer is null — open (or reopen after Flush/size-cap rotation).
+		Directory.CreateDirectory(_logDirectory);
+
+		if (today != _currentDate)
+		{
+			// First write of a new day — clean stale logs first.
+			DeleteOldLogs(today);
+			_currentDate = today;
+		}
+
+		_currentLogPath = ResolveLogPath(today);
+		_writer = new StreamWriter(
+			new FileStream(_currentLogPath, FileMode.Append, FileAccess.Write, FileShare.Read),
+			Encoding.UTF8,
+			bufferSize: 4096,
+			leaveOpen: false);
+	}
+
+	private string ResolveLogPath(DateOnly date)
+	{
+		var dateStr = date.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+		var basePath = Path.Combine(_logDirectory, $"weather-{dateStr}.log");
+
+		if (!File.Exists(basePath) || !ExceedsSizeCap(basePath))
+		{
+			return basePath;
+		}
+
+		// Size cap exceeded — find next available suffix.
+		for (var suffix = 1; suffix < 100; suffix++)
+		{
+			var rotated = Path.Combine(_logDirectory, $"weather-{dateStr}.{suffix}.log");
+			if (!File.Exists(rotated) || !ExceedsSizeCap(rotated))
+			{
+				return rotated;
+			}
+		}
+
+		// Fallback: overwrite the last suffix slot.
+		return Path.Combine(_logDirectory, $"weather-{dateStr}.99.log");
+	}
+
+	private static bool ExceedsSizeCap(string path)
+	{
+		try
+		{
+			return File.Exists(path) && new FileInfo(path).Length >= MaxFileSizeBytes;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private void DeleteOldLogs(DateOnly today)
+	{
+		try
+		{
+			if (!Directory.Exists(_logDirectory))
+			{
+				return;
+			}
+
+			var cutoff = today.AddDays(-RetentionDays);
+			foreach (var file in Directory.EnumerateFiles(_logDirectory, "weather-*.log"))
+			{
+				var name = Path.GetFileNameWithoutExtension(file);
+				// Parse the date from the filename prefix "weather-yyyy-MM-dd"
+				var datePart = name.Length >= 18 ? name.Substring(8, 10) : null;
+				if (datePart != null &&
+					DateOnly.TryParseExact(datePart, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var fileDate) &&
+					fileDate < cutoff)
+				{
+					File.Delete(file);
+				}
+			}
+		}
+		catch
+		{
+			// Retention cleanup failures are non-fatal.
+		}
+	}
+
+	private void CloseWriter()
+	{
+		try
+		{
+			_writer?.Flush();
+			_writer?.Dispose();
+		}
+		catch
+		{
+			// Ignore disposal errors.
+		}
+		finally
+		{
+			_writer = null;
+		}
+	}
+}

--- a/WeatherExtension/Services/RollingFileLogger.cs
+++ b/WeatherExtension/Services/RollingFileLogger.cs
@@ -18,7 +18,7 @@ internal enum LogLevel
 /// Thread-safe rolling file logger. One file per day, 7-day retention,
 /// 5 MB cap per file. Zero external dependencies — AOT-safe System.IO only.
 /// </summary>
-internal sealed class RollingFileLogger
+internal sealed class RollingFileLogger : IDisposable
 {
 	private const int MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
 	private const int RetentionDays = 7;
@@ -226,4 +226,19 @@ internal sealed class RollingFileLogger
 			_writer = null;
 		}
 	}
+
+	/// <summary>
+	/// Flushes and releases the current log file handle.
+	/// Because this is a singleton that lives for the process lifetime, Dispose
+	/// is effectively called only when the host tears down the extension.
+	/// </summary>
+	public void Dispose()
+	{
+		lock (_sync)
+		{
+			CloseWriter();
+		}
+	}
+
+
 }

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -19,6 +19,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	private readonly FavoritesManager _favoritesManager = new();
 	private readonly WeatherListPage _weatherPage;
 	private readonly WeatherSettingsPage _settingsPage;
+	private readonly SubmitBugPage _submitBugPage = new();
 	private readonly ICommandItem[] _topLevelItems;
 	private readonly Lock _bandsSync = new();
 
@@ -63,7 +64,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 			{
 				Icon = Icons.WeatherIcon,
 				Title = Resources.plugin_name,
-				MoreCommands = [new CommandContextItem(_settingsPage)],
+				MoreCommands = [new CommandContextItem(_settingsPage), new CommandContextItem(_submitBugPage)],
 			},
 		];
 	}

--- a/WeatherExtension/WeatherLogger.cs
+++ b/WeatherExtension/WeatherLogger.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.CommandPalette.Extensions;
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace BaldBeardedBuilder.WeatherExtension;
@@ -12,5 +16,14 @@ internal static class WeatherLogger
 			Message = message,
 			State = state,
 		});
+
+		RollingFileLogger.Instance.Log(MapLevel(state), message);
 	}
+
+	private static LogLevel MapLevel(MessageState state) => state switch
+	{
+		MessageState.Error => LogLevel.Error,
+		MessageState.Warning => LogLevel.Warning,
+		_ => LogLevel.Info,
+	};
 }


### PR DESCRIPTION
## Summary

Implements a self-contained rotating file logger and a "Submit a Bug" command for the Weather Extension.

### Rolling File Logger
- Thread-safe singleton using `Lock` — zero external dependencies, fully AOT-compatible
- Daily log files (`weather-yyyy-MM-dd.log`) in `AppContext.BaseDirectory/Logs/`
- 7-day retention (auto-cleanup on day rollover)
- 5 MB per-file cap with suffix rotation
- `Flush()` releases file handles for safe zip access

### WeatherLogger Dual-Write
- Keeps existing `ExtensionHost.LogMessage()` — CmdPal host still sees events
- Adds `RollingFileLogger.Instance.Log()` — persists to disk
- No call-site changes (41 existing callers unchanged)

### Submit a Bug Command
- Accessible from the context menu (MoreCommands) — not in search results
- `DynamicListPage` with two actions:
  - **Save Logs to Desktop** — zips `*.log` files to `~/Desktop/WeatherExtension-Logs-{date}.zip`
  - **Open GitHub Issues** — launches browser to issues/new
- Step-by-step instructions shown in the Details panel

### Tests
- `RollingFileLoggerTests`: file creation, format, rotation, concurrent writes, flush behavior
- `SubmitBugPageTests`: page metadata, items, details panel

Closes #121