### PR TITLE
test: resx key-completeness test (#128)

### DIFF
--- a/WeatherExtension.Tests/ResxCompletenessTests.cs
+++ b/WeatherExtension.Tests/ResxCompletenessTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+/// <summary>
+/// Verifies that every key in the English baseline <c>Resources.resx</c>
+/// is present in every satellite locale <c>Resources.XX.resx</c> file.
+/// Missing keys silently fall back to English at runtime — these tests make
+/// that visible before it ships.
+/// </summary>
+[TestClass]
+public class ResxCompletenessTests
+{
+    // Resolve the Properties directory relative to the test output directory.
+    // Test output: WeatherExtension.Tests/bin/Debug/net8.0-windows10.0.22621.0/
+    // Target:      WeatherExtension/Properties/
+    private static readonly string PropertiesDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "../../../..", "WeatherExtension", "Properties"));
+
+    private static readonly string BaselineFile = Path.Combine(PropertiesDir, "Resources.resx");
+
+    private static IReadOnlyList<string> ReadKeys(string resxPath)
+    {
+        var doc = XDocument.Load(resxPath);
+        return doc.Root!
+            .Elements("data")
+            .Select(e => e.Attribute("name")!.Value)
+            .ToList();
+    }
+
+    [TestMethod]
+    public void AllLocaleFiles_ContainEveryBaselineKey()
+    {
+        Assert.IsTrue(File.Exists(BaselineFile),
+            $"English baseline not found at: {BaselineFile}");
+
+        var baselineKeys = ReadKeys(BaselineFile);
+        Assert.IsTrue(baselineKeys.Count > 0, "Baseline resx has no data keys — check the file path.");
+
+        var localeFiles = Directory.GetFiles(PropertiesDir, "Resources.*.resx")
+                                   .OrderBy(f => f)
+                                   .ToList();
+
+        Assert.IsTrue(localeFiles.Count > 0,
+            $"No locale resx files found in: {PropertiesDir}");
+
+        var failures = new List<string>();
+
+        foreach (var localeFile in localeFiles)
+        {
+            var localeName = Path.GetFileNameWithoutExtension(localeFile)
+                                 .Substring("Resources.".Length); // e.g. "ar", "zh-Hans"
+            var localeKeys = new HashSet<string>(ReadKeys(localeFile));
+
+            var missing = baselineKeys.Where(k => !localeKeys.Contains(k)).ToList();
+            if (missing.Count > 0)
+            {
+                failures.Add(
+                    $"\n  [{localeName}] missing {missing.Count} key(s): {string.Join(", ", missing)}");
+            }
+        }
+
+        Assert.AreEqual(0, failures.Count,
+            $"The following locale files are missing keys from the English baseline:{string.Join(string.Empty, failures)}\n\n" +
+            $"Add the missing translations or placeholder values to each affected .resx file.");
+    }
+
+    [TestMethod]
+    public void BaselineFile_IsReachableFromTestOutput()
+    {
+        Assert.IsTrue(File.Exists(BaselineFile),
+            $"Could not find Resources.resx at expected path: {BaselineFile}\n" +
+            $"AppContext.BaseDirectory = {AppContext.BaseDirectory}");
+    }
+
+    [TestMethod]
+    public void LocaleFiles_ArePresent()
+    {
+        var localeFiles = Directory.GetFiles(PropertiesDir, "Resources.*.resx");
+        Assert.IsTrue(localeFiles.Length >= 13,
+            $"Expected at least 13 locale files but found {localeFiles.Length} in {PropertiesDir}");
+    }
+}


### PR DESCRIPTION
Adds a test that fails if any satellite .resx locale file is missing a key from the English baseline. Catches incomplete translations before they ship.

Closes #128

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>