### PR TITLE
feat: add nighttime weather icons based on sunrise/sunset

### DIFF
--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -107,7 +107,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 					"{0} {1}",
 					WeatherFormatter.Temperature(current.Temperature, tempUnit),
 					condition);
-				Icon = Icons.GetIconForWeatherCode(current.WeatherCode);
+				Icon = Icons.GetIconForWeatherCode(current.WeatherCode, isNight: current.IsDay == 0);
 
 				if (DockItem is CommandItem dockCommandItem)
 				{

--- a/WeatherExtension/Icons.cs
+++ b/WeatherExtension/Icons.cs
@@ -50,13 +50,22 @@ internal sealed class Icons
 
     internal static IconInfo ThunderstormHail { get; } = new IconInfo("⛈️");
 
-    internal static IconInfo GetIconForWeatherCode(int weatherCode)
+    // Nighttime variants
+    internal static IconInfo ClearSkyNight { get; } = new IconInfo("🌙");
+
+    internal static IconInfo MainlyClearNight { get; } = new IconInfo("🌙");
+
+    internal static IconInfo PartlyCloudyNight { get; } = new IconInfo("☁️");
+
+    internal static IconInfo WeatherIconNight { get; } = new IconInfo("🌙");
+
+    internal static IconInfo GetIconForWeatherCode(int weatherCode, bool isNight = false)
     {
         return weatherCode switch
         {
-            0 => ClearSky,
-            1 or 2 => MainlyClear,
-            3 => PartlyCloudy,
+            0 => isNight ? ClearSkyNight : ClearSky,
+            1 or 2 => isNight ? MainlyClearNight : MainlyClear,
+            3 => isNight ? PartlyCloudyNight : PartlyCloudy,
             45 or 48 => Fog,
             51 or 53 or 55 => Drizzle,
             56 or 57 => DrizzleFreezing,
@@ -67,7 +76,7 @@ internal sealed class Icons
             85 or 86 => SnowShowers,
             95 => Thunderstorm,
             96 or 99 => ThunderstormHail,
-            _ => WeatherIcon,
+            _ => isNight ? WeatherIconNight : WeatherIcon,
         };
     }
 

--- a/WeatherExtension/Models/ForecastData.cs
+++ b/WeatherExtension/Models/ForecastData.cs
@@ -39,12 +39,21 @@ public sealed class DailyForecast
 
     [JsonPropertyName("precipitation_probability_max")]
     public List<int>? PrecipitationProbabilityMax { get; set; }
+
+    [JsonPropertyName("sunrise")]
+    public List<string>? Sunrise { get; set; }
+
+    [JsonPropertyName("sunset")]
+    public List<string>? Sunset { get; set; }
 }
 
 public sealed class HourlyForecastData
 {
     [JsonPropertyName("hourly")]
     public HourlyForecast? Hourly { get; set; }
+
+    [JsonPropertyName("daily")]
+    public HourlyDailyInfo? Daily { get; set; }
 
     [JsonPropertyName("latitude")]
     public double Latitude { get; set; }
@@ -78,6 +87,15 @@ public sealed class HourlyForecast
 
     [JsonPropertyName("relative_humidity_2m")]
     public List<int>? RelativeHumidity { get; set; }
+}
+
+public sealed class HourlyDailyInfo
+{
+    [JsonPropertyName("sunrise")]
+    public List<string>? Sunrise { get; set; }
+
+    [JsonPropertyName("sunset")]
+    public List<string>? Sunset { get; set; }
 }
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/WeatherExtension/Models/WeatherData.cs
+++ b/WeatherExtension/Models/WeatherData.cs
@@ -45,6 +45,9 @@ public sealed class CurrentWeather
 
     [JsonPropertyName("wind_direction_10m")]
     public int WindDirection { get; set; }
+
+    [JsonPropertyName("is_day")]
+    public int IsDay { get; set; } = 1;
 }
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/WeatherExtension/Pages/HourlyForecastPage.cs
+++ b/WeatherExtension/Pages/HourlyForecastPage.cs
@@ -93,6 +93,10 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 		var windUnit = _settingsManager.WindSpeedUnit == "mph" ? "mph" : "km/h";
 		var now = DateTime.Now;
 
+		// Parse sunrise/sunset times for night determination
+		var sunriseTimes = ParseDailyTimes(hourlyData.Daily?.Sunrise);
+		var sunsetTimes = ParseDailyTimes(hourlyData.Daily?.Sunset);
+
 		var count = hourly.Time?.Count ?? 0;
 		for (var i = 0; i < count; i++)
 		{
@@ -122,6 +126,7 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 			var temperature = hourly.Temperature[i];
 			var feelsLike = hourly.ApparentTemperature[i];
 			var condition = Icons.GetWeatherDescription(weatherCode);
+			var isNight = IsNightTime(time, sunriseTimes, sunsetTimes);
 
 			var precipProb = hourly.PrecipitationProbability != null && i < hourly.PrecipitationProbability.Count
 				? hourly.PrecipitationProbability[i]
@@ -139,7 +144,7 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 			{
 				Title = WeatherFormatter.Hour(time, _settingsManager.Use24HourClock),
 				Subtitle = $"{condition} — {temperature:F0}{tempUnit}",
-				Icon = Icons.GetIconForWeatherCode(weatherCode),
+				Icon = Icons.GetIconForWeatherCode(weatherCode, isNight),
 				Details = new Details
 				{
 					Title = WeatherFormatter.Hour(time, _settingsManager.Use24HourClock),
@@ -157,6 +162,39 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 		}
 
 		return items;
+	}
+
+	private static List<DateTime> ParseDailyTimes(List<string>? times)
+	{
+		var result = new List<DateTime>();
+		if (times == null)
+		{
+			return result;
+		}
+
+		foreach (var t in times)
+		{
+			if (DateTime.TryParse(t, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+			{
+				result.Add(parsed);
+			}
+		}
+
+		return result;
+	}
+
+	private static bool IsNightTime(DateTime time, List<DateTime> sunriseTimes, List<DateTime> sunsetTimes)
+	{
+		// Find the sunrise/sunset for the same day
+		var sunrise = sunriseTimes.FirstOrDefault(s => s.Date == time.Date);
+		var sunset = sunsetTimes.FirstOrDefault(s => s.Date == time.Date);
+
+		if (sunrise == default || sunset == default)
+		{
+			return false;
+		}
+
+		return time < sunrise || time >= sunset;
 	}
 
 	public override IListItem[] GetItems()

--- a/WeatherExtension/Pages/WeatherDetailPage.cs
+++ b/WeatherExtension/Pages/WeatherDetailPage.cs
@@ -112,7 +112,7 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 		{
 			Title = Resources.current_weather,
 			Subtitle = $"{condition} — {current.Temperature:F0}{tempUnit}",
-			Icon = Icons.GetIconForWeatherCode(current.WeatherCode),
+			Icon = Icons.GetIconForWeatherCode(current.WeatherCode, isNight: current.IsDay == 0),
 			Details = new Details
 			{
 				Title = Resources.current_weather,

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -284,7 +284,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		{
 			Title = location.DisplayName,
 			Subtitle = WeatherFormatter.CurrentSubtitle(current, _settingsManager.TemperatureUnit),
-			Icon = Icons.GetIconForWeatherCode(current.WeatherCode),
+			Icon = Icons.GetIconForWeatherCode(current.WeatherCode, isNight: current.IsDay == 0),
 			Tags = tags.ToArray(),
 			Details = new Details
 			{

--- a/WeatherExtension/Services/OpenMeteoService.cs
+++ b/WeatherExtension/Services/OpenMeteoService.cs
@@ -73,7 +73,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			var url = string.Create(
 				CultureInfo.InvariantCulture,
-				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&timezone=auto");
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,is_day&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 
@@ -143,7 +143,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			var url = string.Create(
 				CultureInfo.InvariantCulture,
-				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&temperature_unit={temperatureUnit}&timezone=auto");
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max,sunrise,sunset&temperature_unit={temperatureUnit}&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 
@@ -214,7 +214,7 @@ public sealed partial class OpenMeteoService : IWeatherService, IDisposable
 
 			var url = string.Create(
 				CultureInfo.InvariantCulture,
-				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&hourly=temperature_2m,apparent_temperature,weather_code,precipitation_probability,wind_speed_10m,relative_humidity_2m&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&forecast_days=2&timezone=auto");
+				$"{BaseUrl}?latitude={latitude}&longitude={longitude}&hourly=temperature_2m,apparent_temperature,weather_code,precipitation_probability,wind_speed_10m,relative_humidity_2m&daily=sunrise,sunset&temperature_unit={temperatureUnit}&wind_speed_unit={windSpeedUnit}&forecast_days=2&timezone=auto");
 
 			var response = await _httpClient.GetAsync(url, ct).ConfigureAwait(false);
 

--- a/WeatherExtension/Services/WeatherJsonContext.cs
+++ b/WeatherExtension/Services/WeatherJsonContext.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CmdPal.Ext.Weather.Services;
 [JsonSerializable(typeof(WeatherData))]
 [JsonSerializable(typeof(ForecastData))]
 [JsonSerializable(typeof(HourlyForecastData))]
+[JsonSerializable(typeof(HourlyDailyInfo))]
 [JsonSerializable(typeof(List<NominatimResult>))]
 [JsonSerializable(typeof(NominatimAddress))]
 [JsonSerializable(typeof(List<PinnedLocation>))]


### PR DESCRIPTION
## Summary

Displays moon/night icons when the current time is after sunset or before sunrise, addressing the issue where the sun icon was displayed at night.

## Changes

- **Model updates**: Added `IsDay` property to `CurrentWeather`, `Sunrise`/`Sunset` to `DailyForecast`, and new `HourlyDailyInfo` class for hourly forecast sunrise/sunset data
- **API requests**: Updated Open-Meteo API calls to request `is_day` (current weather), `sunrise,sunset` (forecast and hourly forecast)
- **Nighttime icons**: Added `ClearSkyNight` (🌙), `MainlyClearNight` (🌙), `PartlyCloudyNight` (☁️), and `WeatherIconNight` (🌙) variants
- **Icon selection**: Updated `GetIconForWeatherCode` with an optional `isNight` parameter that selects night variants for clear/partly cloudy conditions
- **Caller updates**: 
  - `PinnedWeatherBand`, `WeatherDetailPage`, `WeatherListPage` use `current.IsDay == 0`
  - `HourlyForecastPage` compares each hour against sunrise/sunset times

## Design decisions

- Only clear sky, mainly clear, and partly cloudy conditions get night variants — precipitation/fog/snow icons are already appropriate for any time of day
- Daily forecast items remain as daytime icons since they represent the whole day
- Falls back to daytime icons if sunrise/sunset data is unavailable

Closes #138