### PR TITLE
Fix dock band not updating after sleep/hibernation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260204002-experimental" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />

--- a/WeatherExtension/DockBands/PinnedWeatherBand.cs
+++ b/WeatherExtension/DockBands/PinnedWeatherBand.cs
@@ -8,6 +8,7 @@ using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.Win32;
 using System.Globalization;
 using Timer = System.Timers.Timer;
 
@@ -20,7 +21,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 	private readonly WeatherSettingsManager _settings;
 	private readonly WeatherBandCard _contentPage;
 	private readonly Timer _updateTimer;
-	private readonly CancellationTokenSource _cts = new();
+	private CancellationTokenSource _cts = new();
 	private bool _isDisposed;
 	private int _isUpdating;
 
@@ -50,6 +51,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		_updateTimer.Start();
 
 		_settings.Settings.SettingsChanged += OnSettingsChanged;
+		SystemEvents.PowerModeChanged += OnPowerModeChanged;
 
 		_ = UpdateWeatherAsync();
 	}
@@ -69,6 +71,48 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 			WeatherLogger.LogToHost(
 				MessageState.Error,
 				$"Pinned band timer tick failed: {ex.Message}");
+		}
+	}
+
+	private async void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+	{
+		if (e.Mode != PowerModes.Resume || _isDisposed)
+		{
+			return;
+		}
+
+		try
+		{
+			// Cancel any in-flight request that may be stuck from before
+			// sleep and replace the CTS so the next update uses a fresh token.
+			var stale = Interlocked.Exchange(ref _cts, new CancellationTokenSource());
+			try
+			{
+				stale.Cancel();
+			}
+			catch (ObjectDisposedException)
+			{
+			}
+
+			stale.Dispose();
+
+			// Clear the re-entrancy guard in case the previous request is
+			// still holding it (its catch/finally will run on the cancelled
+			// token path, but a race is possible).
+			Interlocked.Exchange(ref _isUpdating, 0);
+
+			// Restart the timer so the next tick is a full interval away
+			// from this fresh update rather than firing immediately after.
+			_updateTimer.Stop();
+			_updateTimer.Start();
+
+			await UpdateWeatherAsync().ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Error,
+				$"Pinned band resume refresh failed: {ex.Message}");
 		}
 	}
 
@@ -232,6 +276,7 @@ internal sealed partial class PinnedWeatherBand : ListItem, IDisposable
 		// in-flight work to cancel, then dispose the cancellation source and
 		// the inner content page so its own subscriptions get released too.
 		_isDisposed = true;
+		SystemEvents.PowerModeChanged -= OnPowerModeChanged;
 		_settings.Settings.SettingsChanged -= OnSettingsChanged;
 		_updateTimer.Elapsed -= OnTimerElapsed;
 		_updateTimer.Stop();

--- a/WeatherExtension/WeatherExtension.csproj
+++ b/WeatherExtension/WeatherExtension.csproj
@@ -56,6 +56,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CommandPalette.Extensions" />
+		<PackageReference Include="Microsoft.Win32.SystemEvents" />
 		<PackageReference Include="Microsoft.Windows.CsWinRT" />
 		<PackageReference Include="Shmuelie.WinRTServer" />
 		<PackageReference Include="System.Text.Json" />


### PR DESCRIPTION
## Problem

After the system resumes from sleep or hibernation, the dock band for a pinned location stops updating its title/subtitle with fresh weather data.

**Root cause:** An in-flight HTTP request at the time of sleep could hold the `_isUpdating` re-entrancy guard indefinitely (`1`), blocking all subsequent timer ticks from executing `UpdateWeatherAsync`. Additionally, `System.Timers.Timer` doesn't guarantee an immediate tick on resume, leaving stale data displayed.

## Fix

Subscribe to `SystemEvents.PowerModeChanged` in `PinnedWeatherBand` and on `Resume`:

1. Cancel the stale `CancellationTokenSource` and swap in a fresh one (via `Interlocked.Exchange`)
2. Reset `_isUpdating` to `0` so updates aren't blocked
3. Restart the timer for a clean interval from the resume point
4. Immediately trigger `UpdateWeatherAsync()` for fresh weather data

The handler is properly unsubscribed in `Dispose()`.

## Testing

All 296 existing tests pass. The structural/IL-level tests in `DockBandCardSyncTests` continue to validate the timer and content-page sync contracts.