### PR TITLE
perf: defer page loads and dispose detail pages

### DIFF
--- a/WeatherExtension/Pages/HourlyForecastPage.cs
+++ b/WeatherExtension/Pages/HourlyForecastPage.cs
@@ -21,6 +21,7 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 
 	private IListItem[] _items = [];
 	private bool _isLoading = true;
+	private int _loadStarted;
 
 	public HourlyForecastPage(
 		GeocodingResult location,
@@ -41,7 +42,18 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 		Id = $"com.baldbeardedbuilder.cmdpal.weather.hourly.{location.Id}";
 		ShowDetails = true;
 
-		LoadHourlyData();
+		// Loading is deferred until the host first renders the page (GetItems).
+		// Constructing this page no longer triggers a network call, so callers
+		// that create it speculatively (e.g. list rows the user never opens)
+		// don't pay for an hourly-forecast fetch.
+	}
+
+	private void EnsureLoadStarted()
+	{
+		if (Interlocked.Exchange(ref _loadStarted, 1) == 0)
+		{
+			LoadHourlyData();
+		}
 	}
 
 	private async void LoadHourlyData()
@@ -199,6 +211,8 @@ internal sealed partial class HourlyForecastPage : ListPage, IDisposable
 
 	public override IListItem[] GetItems()
 	{
+		EnsureLoadStarted();
+
 		lock (_sync)
 		{
 			if (_isLoading)

--- a/WeatherExtension/Pages/WeatherDetailPage.cs
+++ b/WeatherExtension/Pages/WeatherDetailPage.cs
@@ -21,6 +21,8 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 
 	private IListItem[] _items = [];
 	private bool _isLoading = true;
+	private int _loadStarted;
+	private HourlyForecastPage? _hourlyPage;
 
 	public WeatherDetailPage(
 		GeocodingResult location,
@@ -41,7 +43,17 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 		Id = $"com.baldbeardedbuilder.cmdpal.weather.detail.{location.Id}";
 		ShowDetails = true;
 
-		LoadWeatherData();
+		// Loading is deferred until the host first renders the page (GetItems).
+		// This page is created for every search/favorite row, but only fetches
+		// weather (and builds its nested hourly page) once the user opens it.
+	}
+
+	private void EnsureLoadStarted()
+	{
+		if (Interlocked.Exchange(ref _loadStarted, 1) == 0)
+		{
+			LoadWeatherData();
+		}
 	}
 
 	private async void LoadWeatherData()
@@ -107,6 +119,7 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 		var condition = Icons.GetWeatherDescription(current.WeatherCode);
 
 		var hourlyPage = new HourlyForecastPage(_location, _weatherService, _settingsManager);
+		_hourlyPage = hourlyPage;
 
 		return new ListItem(hourlyPage)
 		{
@@ -191,6 +204,8 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 
 	public override IListItem[] GetItems()
 	{
+		EnsureLoadStarted();
+
 		lock (_sync)
 		{
 			if (_isLoading)
@@ -213,6 +228,7 @@ internal sealed partial class WeatherDetailPage : ListPage, IDisposable
 	{
 		_cts?.Cancel();
 		_cts?.Dispose();
+		_hourlyPage?.Dispose();
 		GC.SuppressFinalize(this);
 	}
 }

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -24,6 +24,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	private readonly CancellationTokenSource _cts = new();
 
 	private IListItem[] _items = [];
+	private readonly List<WeatherDetailPage> _detailPages = [];
 	private bool _isLoading;
 	private int _favoritesLoadGeneration;
 	private string _lastSearchQuery = string.Empty;
@@ -61,6 +62,10 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	private async void LoadFavoriteLocations(CancellationToken searchCt = default)
 	{
 		var generation = Interlocked.Increment(ref _favoritesLoadGeneration);
+
+		// Release the detail pages built for the previous set of rows before
+		// this load replaces them.
+		DisposeTrackedDetailPages();
 
 		try
 		{
@@ -254,6 +259,11 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			_weatherService,
 			_settingsManager);
 
+		lock (_sync)
+		{
+			_detailPages.Add(detailPage);
+		}
+
 		var moreCommands = new List<ICommandContextItem>
 		{
 			new CommandContextItem(new RefreshWeatherCommand(this)),
@@ -340,6 +350,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			ResetSearchToken();
 			_lastSearchQuery = newSearch;
 			EmptyContent = BuildSearchHintCard(Resources.search_min_chars);
+			DisposeTrackedDetailPages();
 			lock (_sync)
 			{
 				_items = [];
@@ -386,6 +397,10 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	{
 		try
 		{
+			// Release the detail pages built for the previous set of rows before
+			// this search replaces them.
+			DisposeTrackedDetailPages();
+
 			lock (_sync)
 			{
 				_isLoading = true;
@@ -538,6 +553,31 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 	}
 
+	// Disposes the WeatherDetailPage instances created for the previous set of
+	// rows. Each detail page owns a CancellationTokenSource, so dropping the
+	// items array without disposing them would leak those pages until GC. Called
+	// at the start of every fresh load, before the next generation of rows is
+	// built, so only superseded pages are released.
+	private void DisposeTrackedDetailPages()
+	{
+		WeatherDetailPage[] toDispose;
+		lock (_sync)
+		{
+			if (_detailPages.Count == 0)
+			{
+				return;
+			}
+
+			toDispose = _detailPages.ToArray();
+			_detailPages.Clear();
+		}
+
+		foreach (var page in toDispose)
+		{
+			page.Dispose();
+		}
+	}
+
 	public override IListItem[] GetItems()
 	{
 		lock (_sync)
@@ -566,5 +606,6 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		_searchCts?.Dispose();
 		_cts?.Cancel();
 		_cts?.Dispose();
+		DisposeTrackedDetailPages();
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a performance issue and a related memory leak found while reviewing the extension for eager work and undisposed resources.

### 1. Eager network I/O in page constructors (performance)
`WeatherDetailPage` and `HourlyForecastPage` started their network fetches from their **constructors**. Because `WeatherListPage.CreateWeatherItem` builds a `WeatherDetailPage` for *every* result row (up to 10 per search), a single multi-result search eagerly fired ~10 forecast requests — and each opened detail page eagerly built an `HourlyForecastPage` that fired an hourly request — for pages the user usually never opens. `ViewHourlyCommand` even constructed a page, used its `Id`, and discarded the object (a wasted fetch).

**Fix:** both pages now load lazily on the first `GetItems()` call (guarded by an `Interlocked` flag), matching the existing `_isLoading` sentinel pattern. Rows cost nothing until actually opened.

### 2. Undisposed detail pages (memory leak)
`WeatherListPage` created `WeatherDetailPage` instances (each `IDisposable`, owning a `CancellationTokenSource`) but never disposed them as `_items` was replaced on every keystroke / refresh / favorites reload.

**Fix:** `WeatherListPage` now tracks the detail pages it creates and disposes the previous generation at the start of each fresh load (search, favorites reload, short-query clear) and all remaining on `Dispose()`. `WeatherDetailPage` also disposes the nested `HourlyForecastPage` it creates.

## Files changed
- `Pages/HourlyForecastPage.cs` — lazy load
- `Pages/WeatherDetailPage.cs` — lazy load + dispose nested hourly page
- `Pages/WeatherListPage.cs` — track & dispose detail pages

## Testing
- `dotnet build WeatherExtension.slnx -c Debug` — succeeds
- `dotnet test WeatherExtension.Tests -r win-x64` — **296 passed, 0 failed**

## Notes
The lazy-load trigger is compatible with existing tests, which poll `GetItems()` until data appears. `LoadFavoriteLocations`' incremental `_items` rebuild was left as-is intentionally — it's a deliberate progressive-render UX and negligible for realistic favorite counts.