### PR TITLE
Submit a multi-arch .msixbundle to the Store instead of a package directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,37 +297,56 @@ jobs:
             Write-Host "  $($_.FullName) ($([math]::Round($_.Length / 1MB, 2)) MB)"
           }
 
-      - name: Bundle Store MSIX packages into .msixupload
+      - name: Create multi-architecture .msixbundle
         id: bundle
         shell: pwsh
         run: |
           $version = "${{ needs.build-and-test.outputs.version }}"
 
-          # msstore publish -i expects a single '.msix' or '.msixupload' FILE, not a
-          # directory. Passing a directory makes the CLI ignore the input and clone the
-          # previously published submission (which re-publishes stale packages). A
-          # '.msixupload' is a plain ZIP that can carry all architecture-specific .msix
-          # packages, so bundle them into one file to submit as-is.
+          # 'msstore publish' picks its publisher from the *extension* of the positional
+          # argument and uploads exactly that single file. Previously we passed the
+          # project name ('WeatherExtension'), so the CLI treated it as a project, ran
+          # its own project detection/packaging, gathered none of our prebuilt packages,
+          # and committed the submission that Partner Center clones from the last
+          # published one -- re-publishing the stale 1.1.0.0 packages every release.
+          #
+          # A single multi-architecture .msixbundle sidesteps all of that: it is selected
+          # deterministically by extension and carries both x64 and arm64 at the correct
+          # version, so the freshly built packages are what actually gets submitted.
           $msixFiles = Get-ChildItem -Path "msix-packages" -Filter "*.msix" -Recurse
           if ($msixFiles.Count -eq 0) {
             Write-Error "No MSIX packages found to bundle!"
             exit 1
           }
 
+          # Stage the .msix packages in a clean folder so makeappx bundles only them.
+          $bundleInput = Join-Path $env:GITHUB_WORKSPACE "bundle-input"
+          New-Item -Path $bundleInput -ItemType Directory -Force | Out-Null
+          $msixFiles | ForEach-Object { Copy-Item $_.FullName -Destination $bundleInput }
+
+          $makeappx = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\makeappx.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $makeappx) {
+            Write-Error "makeappx.exe not found in the Windows SDK."
+            exit 1
+          }
+          Write-Host "Using makeappx: $($makeappx.FullName)"
+
           $uploadDir = Join-Path $env:GITHUB_WORKSPACE "store-upload"
           New-Item -Path $uploadDir -ItemType Directory -Force | Out-Null
+          $bundlePath = Join-Path $uploadDir "WeatherExtension_$version.msixbundle"
 
-          $zipPath = Join-Path $uploadDir "WeatherExtension_$version.zip"
-          $uploadPath = Join-Path $uploadDir "WeatherExtension_$version.msixupload"
+          & $makeappx.FullName bundle /d $bundleInput /bv $version /p $bundlePath /o
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "makeappx bundle failed with exit code $LASTEXITCODE"
+            exit 1
+          }
 
-          Compress-Archive -Path $msixFiles.FullName -DestinationPath $zipPath -Force
-          Move-Item -Path $zipPath -Destination $uploadPath -Force
-
-          $resolved = (Resolve-Path $uploadPath).Path
-          Write-Host "Created .msixupload bundle: $resolved"
+          $resolved = (Resolve-Path $bundlePath).Path
+          Write-Host "Created .msixbundle: $resolved"
           Write-Host "Bundled packages:"
           $msixFiles | ForEach-Object { Write-Host "  $($_.Name)" }
-          echo "upload_file=$resolved" >> $env:GITHUB_OUTPUT
+          echo "bundle_file=$resolved" >> $env:GITHUB_OUTPUT
 
       - name: Setup Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.3
@@ -344,7 +363,7 @@ jobs:
       - name: Submit to Microsoft Store
         shell: pwsh
         run: |
-          msstore publish WeatherExtension -i "${{ steps.bundle.outputs.upload_file }}" -id "${{ secrets.STORE_PRODUCT_ID }}"
+          msstore publish "${{ steps.bundle.outputs.bundle_file }}" -id "${{ secrets.STORE_PRODUCT_ID }}"
 
   winget-publish:
     needs: [package, build-and-test]


### PR DESCRIPTION
## Problem

Two separate failures in the `store-submit` job:

1. **Original bug (runs before #146):** `msstore publish WeatherExtension -i msix-packages` passed the *project name* as the positional argument. The msstore CLI treated it as a project, ran its own project detection/packaging, gathered none of our prebuilt packages, and committed the submission that Partner Center clones from the last published one — **re-publishing stale `1.1.0.0` packages every release**, even though `1.2.x` artifacts were built and downloaded.

2. **#146's regression:** That PR passed a `.msixupload` **file** to `msstore publish -i`. But the installed CLI (`microsoft/microsoft-store-apppublisher@v1.3` → msstore CLI v0.3.9) treats `-i/--inputDirectory` as a **directory**, so the job failed at runtime with `Input directory does not exist.`

## Root cause

The installed msstore CLI selects its publisher from the **file extension** of the positional `pathOrUrl` argument (`.msix`, `.msixbundle`, `.msixupload`) and uploads **exactly that one file** — it does not gather sibling files or rebuild. Passing a project name or a directory sends it down the fragile project-detection path.

## Fix

Build a single multi-architecture **`.msixbundle`** from the prebuilt x64/arm64 `.msix` packages with `makeappx`, and pass it as the **positional argument** (with `-id` to resolve the app):

```
msstore publish "<...>.msixbundle" -id "<STORE_PRODUCT_ID>"
```

This is selected deterministically by extension and carries both architectures at the correct version, so the freshly built packages are what actually gets submitted.

## Notes

- The winget-publish failure is tracked separately — the package exists in `microsoft/winget-pkgs` but komac reports "does not exist", which points at the `WINGET_TOKEN` PAT scope/expiry or a komac regression, not this change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>