### PR TITLE
Fix stale-package cleanup deleting the new bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,15 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
 
+          # Surface the API response body on any failing REST call (PowerShell otherwise
+          # only shows the status line and hides the useful error detail).
+          trap {
+            if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+              Write-Host "API error response: $($_.ErrorDetails.Message)"
+            }
+            break
+          }
+
           $tenantId     = "${{ secrets.PARTNER_CENTER_TENANT_ID }}"
           $clientId     = "${{ secrets.PARTNER_CENTER_CLIENT_ID }}"
           $clientSecret = "${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}"
@@ -416,18 +425,30 @@ jobs:
           $submissionUri = "$base/submissions/$subId"
           $submission = Invoke-RestMethod -Method Get -Uri $submissionUri -Headers $headers
 
-          # --- Step 3: mark every package that isn't this release for deletion ---
+          # --- Step 3: mark inherited packages for deletion ---
+          # Discriminate by fileStatus, NOT version: a freshly uploaded package is
+          # "PendingUpload" and its version field is still empty (Partner Center hasn't
+          # extracted its manifest yet), so a version comparison would wrongly match it.
+          # Every "Uploaded" package is inherited from the previously published submission
+          # and must go; the new bundle we just uploaded is "PendingUpload" and is kept.
           Write-Host "Release version: $version"
           Write-Host "Packages in draft:"
           $changed = $false
           foreach ($p in $submission.applicationPackages) {
             $marker = ""
-            if ($p.version -ne $version -and $p.fileStatus -ne "PendingDelete") {
+            if ($p.fileStatus -eq "Uploaded") {
               $p.fileStatus = "PendingDelete"
               $changed = $true
               $marker = "  <-- marked for deletion"
             }
             Write-Host "  $($p.fileName) v$($p.version) [$($p.fileStatus)]$marker"
+          }
+
+          # Safety guard: never commit a submission with no surviving package.
+          $surviving = @($submission.applicationPackages | Where-Object { $_.fileStatus -ne "PendingDelete" })
+          if ($surviving.Count -eq 0) {
+            Write-Error "Refusing to commit: every package is marked PendingDelete. The new bundle should still be PendingUpload."
+            exit 1
           }
 
           # --- Step 4: PUT the edited draft (only when something changed) ---


### PR DESCRIPTION
## Problem

The first run of the cleanup step (from #148) failed at the `PUT`:

```
InvalidParameterValue ... Existing Package ...
```

The draft it read looked like this:

```
WeatherExtension_1.1.0.0_arm64.msix   v1.1.0.0   [Uploaded]      -> delete (correct)
WeatherExtension_1.1.0.0_x64.msix     v1.1.0.0   [Uploaded]      -> delete (correct)
WeatherExtension_1.2.4.0.msixbundle   v1.2.4.0   [PendingDelete] (msstore already marked)
WeatherExtension_1.2.5.0.msixbundle   v(empty)   [PendingUpload] -> WRONGLY deleted ❌
```

The **newly uploaded** bundle is still `PendingUpload`, so Partner Center hasn't extracted its manifest yet and its `version` field is **empty**. The `version != release` filter matched the empty string and marked the new bundle `PendingDelete` too — so the `PUT` tried to delete every package (and you can't set a `PendingUpload` package to `PendingDelete`), which the API rejected.

## Fix

Discriminate by **`fileStatus`, not `version`**:

- Every inherited package from the last published submission is `Uploaded` → mark those `PendingDelete`.
- The bundle we just uploaded is `PendingUpload` → always keep it.

This drops all reliance on the version field. Also added:

- A **safety guard** that refuses to commit if no package would survive (belt-and-suspenders against ever deleting the release payload).
- A **`trap`** that prints the API's response body on any failing REST call, so future failures show the real error instead of just the status line.

## What happens next

The failed run left an uncommitted pending draft on the Store; the next release's `msstore publish --noCommit` deletes any existing pending submission before creating a fresh one, so it's cleaned up automatically — no manual action needed. Merge this, then cut a new release to exercise it.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>