### PR TITLE
Add WINGET_TOKEN preflight to unmask komac's error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,57 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Preflight - validate WINGET_TOKEN
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          # komac masks every HTTP error on its package-existence check as
+          # "<id> does not exist in microsoft/winget-pkgs", which hides the real cause
+          # (almost always a rejected token -> 401). This step exercises the same reads
+          # komac performs, with the same WINGET_TOKEN, and prints the true HTTP status.
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_TOKEN)) {
+            Write-Error "WINGET_TOKEN secret is empty or unset."
+            exit 1
+          }
+          if ($env:WINGET_TOKEN -ne $env:WINGET_TOKEN.Trim()) {
+            Write-Warning "WINGET_TOKEN has leading/trailing whitespace - re-save the secret without newlines."
+          }
+
+          $auth = @{ Authorization = "Bearer $($env:WINGET_TOKEN.Trim())"; "User-Agent" = "winget-preflight"; Accept = "application/vnd.github+json" }
+
+          # 1) Who is this token, and what classic scopes does it carry?
+          $u = Invoke-WebRequest -Uri "https://api.github.com/user" -Headers $auth -SkipHttpErrorCheck
+          Write-Host "GET /user                 -> HTTP $($u.StatusCode)"
+          Write-Host "  x-oauth-scopes:         '$($u.Headers['x-oauth-scopes'])'"
+          Write-Host "  x-ratelimit-remaining:  $($u.Headers['x-ratelimit-remaining'])"
+          if ($u.StatusCode -eq 200) {
+            Write-Host "  authenticated as:       $(($u.Content | ConvertFrom-Json).login)"
+          }
+
+          # 2) REST read of the package folder (proves the package is visible to this token).
+          $pkg = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/b/BaldBeardedBuilder/WeatherforCommandPalette"
+          $r = Invoke-WebRequest -Uri $pkg -Headers $auth -SkipHttpErrorCheck
+          Write-Host "GET package manifest path -> HTTP $($r.StatusCode)"
+
+          # 3) GraphQL viewer query - komac uses the GraphQL API, so this mirrors it best.
+          $g = Invoke-WebRequest -Uri "https://api.github.com/graphql" -Method Post -Headers $auth `
+            -Body '{"query":"{viewer{login}}"}' -SkipHttpErrorCheck
+          Write-Host "POST /graphql viewer      -> HTTP $($g.StatusCode)"
+
+          if ($u.StatusCode -ne 200 -or $g.StatusCode -ne 200) {
+            Write-Host ""
+            Write-Host "WINGET_TOKEN is being REJECTED by GitHub (see HTTP statuses above)."
+            Write-Host "komac reports this as 'does not exist in microsoft/winget-pkgs'."
+            Write-Host "Fix: create a *classic* PAT (not fine-grained) with the 'public_repo' scope,"
+            Write-Host "confirm it is not expired, authorize it for SSO if your account requires it,"
+            Write-Host "and paste it into the WINGET_TOKEN secret with no surrounding whitespace."
+            Write-Error "WINGET_TOKEN failed validation."
+            exit 1
+          }
+          Write-Host ""
+          Write-Host "Token is valid. If komac still reports 'does not exist', the cause is not the token."
+
       - name: Submit to WinGet
         uses: vedantmgoyal9/winget-releaser@v2
         with:


### PR DESCRIPTION
## Problem

`winget-publish` keeps failing with:

```
BaldBeardedBuilder.WeatherforCommandPalette does not exist in microsoft/winget-pkgs
```

But the package **does** exist at the correct path and casing — `manifests/b/BaldBeardedBuilder/WeatherforCommandPalette` currently holds versions `1.0.1.0`, `1.0.4.0`, `1.0.4`, `1.2.1.0`. komac v2.16.0 **collapses every HTTP error on its existence check into that "does not exist" message**, so the real cause is hidden. Reading a public repo needs no special scope, so a masked error there almost always means the token is being rejected (401).

You've re-issued `WINGET_TOKEN` twice and it still fails, so we need to see the *actual* HTTP status instead of komac's masked message.

## What this adds

A **preflight step** that runs before `winget-releaser`, using the same `WINGET_TOKEN`, and prints the ground truth:

1. `GET /user` → HTTP status, `x-oauth-scopes` (classic PATs list scopes here; fine-grained PATs return an **empty** scopes header), and the authenticated login.
2. `GET` the package manifest folder in `microsoft/winget-pkgs` → HTTP status.
3. `POST /graphql` viewer query → HTTP status (komac uses the GraphQL API, so this mirrors it most closely).

It also warns if the secret has surrounding whitespace, and **fails fast with actionable guidance** if `/user` or GraphQL returns non-200.

## How to use it

Merge this and cut a release (or re-run). The preflight output tells us definitively:

- **`/user` = 401** → the token value is invalid/expired/mis-pasted.
- **`/user` = 200 but `x-oauth-scopes` is empty** → it's a fine-grained PAT; komac needs a **classic** PAT with `public_repo`.
- **all 200** → the token is fine and we look elsewhere (komac version, fork state).

No secrets are printed — only HTTP statuses, scopes, and the login name.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>