### PR TITLE
Send application/json content type on Store submission commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,7 +462,11 @@ jobs:
           }
 
           # --- Step 5: commit the submission ---
-          Invoke-RestMethod -Method Post -Uri "$submissionUri/commit" -Headers $headers | Out-Null
+          # The Ingestion API rejects the commit unless the request advertises a JSON
+          # content type, even though the commit itself carries no body. Passing
+          # -ContentType sends the header (Content-Length: 0) and satisfies the check.
+          Invoke-RestMethod -Method Post -Uri "$submissionUri/commit" -Headers $headers `
+            -ContentType "application/json" | Out-Null
           Write-Host "Submission commit requested."
 
           # --- Step 6: poll until the commit is accepted (or fails) ---


### PR DESCRIPTION
## Problem

The latest release (run [28731766511](https://github.com/michaeljolley/WeatherExtension/actions/runs/28731766511), v1.2.6) got further than before — the `fileStatus`-based cleanup fix (#149) correctly marked the stale packages and the `PUT` succeeded — but the `store-submit` job then failed at the **commit** step with:

```json
{
  "message": "Only JSON content is accepted",
  "source": "Ingestion Api",
  "target": "mediaType"
}
```

## Root cause

The commit call is a bodyless `POST .../submissions/{id}/commit`. Because there was no `-Body`, PowerShell sent the request with **no `Content-Type` header**, and the DevCenter Ingestion API rejects the commit unless it advertises `application/json`.

## Fix

Pass `-ContentType "application/json"` on the commit `POST`. Verified against a header-echo endpoint that this sends `Content-Type: application/json` with `Content-Length: 0` on a bodyless request in PowerShell 7 (the `pwsh` used by the runner), which is exactly what the API wants.

## Progression of the store fixes
- #148 — remove stale packages via the submission REST API
- #149 — discriminate stale packages by `fileStatus == "Uploaded"` (not version) so the new bundle isn't deleted → this made the `PUT` succeed
- **this PR** — attach the JSON content type so the final `commit` is accepted

This is the last step in the flow that hadn't yet been exercised, since prior runs failed before reaching a successful commit.