### PR TITLE
Add independent Pin to Dock feature and fix Save Logs to Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ forecasts right from your desktop.
   precipitation chance, and conditions
 - **3-Day Forecast** — Quick glance at upcoming weather with highs, lows, and
   conditions
-- **Dock Bands** — Pin your favorite locations to the Command Palette dock for
-  at-a-glance weather cards
+- **Dock Bands** — Pin a location to the Command Palette dock with the "Pin to
+  Dock" command for an at-a-glance weather card. Dock pinning is independent
+  from Favorites, so you can favorite a location, dock it, or both.
 - **Postal Code Search** — Search by postal/ZIP code or city name
 - **Configurable Units** — Fahrenheit/Celsius, mph/km/h, and adjustable update
   intervals

--- a/WeatherExtension.Tests/CommandInvocationTests.cs
+++ b/WeatherExtension.Tests/CommandInvocationTests.cs
@@ -18,6 +18,7 @@ public class CommandInvocationTests
 {
 	private string _settingsPath = string.Empty;
 	private string _favoritesPath = string.Empty;
+	private string _dockPinsPath = string.Empty;
 	
 
 	[TestInitialize]
@@ -25,12 +26,13 @@ public class CommandInvocationTests
 	{
 		_settingsPath = Path.Combine(Path.GetTempPath(), $"weather-cmd-settings-{Guid.NewGuid()}.json");
 		_favoritesPath = Path.Combine(Path.GetTempPath(), $"weather-cmd-fav-{Guid.NewGuid()}.json");
+		_dockPinsPath = Path.Combine(Path.GetTempPath(), $"weather-cmd-dock-{Guid.NewGuid()}.json");
 	}
 
 	[TestCleanup]
 	public void Cleanup()
 	{
-		foreach (var path in new[] { _settingsPath, _favoritesPath })
+		foreach (var path in new[] { _settingsPath, _favoritesPath, _dockPinsPath })
 		{
 			if (File.Exists(path))
 			{
@@ -112,8 +114,8 @@ public class CommandInvocationTests
 			new StubWeatherService(),
 			new StubGeocodingService(),
 			new WeatherSettingsManager(_settingsPath),
-			
-			new FavoritesManager(_favoritesPath));
+			new FavoritesManager(_favoritesPath),
+			new DockPinsManager(_dockPinsPath));
 	}
 
 }

--- a/WeatherExtension.Tests/DockPinsManagerTests.cs
+++ b/WeatherExtension.Tests/DockPinsManagerTests.cs
@@ -1,0 +1,363 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+
+namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
+
+[TestClass]
+public class DockPinsManagerTests
+{
+    private string _tempFilePath = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"weather-test-dockpins-{Guid.NewGuid()}.json");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // PinToDock() — add
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void PinToDock_AddsLocationToGetDockPins()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult
+        {
+            Name = "Seattle",
+            Latitude = 47.6,
+            Longitude = -122.3,
+            Admin1 = "Washington",
+            Country = "United States",
+        };
+
+        manager.PinToDock(location);
+
+        var pins = manager.GetDockPins();
+        Assert.AreEqual(1, pins.Count);
+        Assert.AreEqual("Seattle", pins[0].Name);
+        Assert.AreEqual(47.6, pins[0].Latitude);
+        Assert.AreEqual(-122.3, pins[0].Longitude);
+    }
+
+    [TestMethod]
+    public void PinToDock_SameLocationTwice_DoesNotDuplicate()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.PinToDock(location);
+        manager.PinToDock(location);
+
+        Assert.AreEqual(1, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void PinToDock_LocationWithinThreshold_DoesNotDuplicate()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location1 = new GeocodingResult { Name = "Seattle", Latitude = 47.6000, Longitude = -122.3000 };
+        var location2 = new GeocodingResult { Name = "Seattle", Latitude = 47.6005, Longitude = -122.3005 };
+
+        manager.PinToDock(location1);
+        manager.PinToDock(location2);
+
+        Assert.AreEqual(1, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void PinToDock_LocationOutsideThreshold_AddsBoth()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location1 = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var location2 = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+
+        manager.PinToDock(location1);
+        manager.PinToDock(location2);
+
+        Assert.AreEqual(2, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void PinToDock_PersistsToFile()
+    {
+        var location = new GeocodingResult
+        {
+            Name = "Portland",
+            Latitude = 45.5152,
+            Longitude = -122.6784,
+            Admin1 = "Oregon",
+            Country = "United States",
+        };
+
+        var manager1 = new DockPinsManager(_tempFilePath);
+        manager1.PinToDock(location);
+
+        var manager2 = new DockPinsManager(_tempFilePath);
+        var pins = manager2.GetDockPins();
+
+        Assert.AreEqual(1, pins.Count);
+        Assert.AreEqual("Portland", pins[0].Name);
+        Assert.AreEqual(45.5152, pins[0].Latitude);
+        Assert.AreEqual(-122.6784, pins[0].Longitude);
+    }
+
+    // ---------------------------------------------------------------
+    // UnpinFromDock() — remove
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void UnpinFromDock_RemovesLocationFromGetDockPins()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.PinToDock(location);
+        manager.UnpinFromDock(location);
+
+        Assert.AreEqual(0, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void UnpinFromDock_NonPinnedLocation_IsNoOp()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.UnpinFromDock(location);
+
+        Assert.AreEqual(0, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void UnpinFromDock_PersistsRemovalToFile()
+    {
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        var manager1 = new DockPinsManager(_tempFilePath);
+        manager1.PinToDock(location);
+        manager1.UnpinFromDock(location);
+
+        var manager2 = new DockPinsManager(_tempFilePath);
+        Assert.AreEqual(0, manager2.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void UnpinFromDock_OnlyRemovesMatchingLocation()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var seattle = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var portland = new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 };
+
+        manager.PinToDock(seattle);
+        manager.PinToDock(portland);
+        manager.UnpinFromDock(seattle);
+
+        var pins = manager.GetDockPins();
+        Assert.AreEqual(1, pins.Count);
+        Assert.AreEqual("Portland", pins[0].Name);
+    }
+
+    // ---------------------------------------------------------------
+    // IsPinnedToDock()
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void IsPinnedToDock_ReturnsTrueForPinnedLocation()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.PinToDock(location);
+
+        Assert.IsTrue(manager.IsPinnedToDock(location));
+    }
+
+    [TestMethod]
+    public void IsPinnedToDock_ReturnsFalseForUnpinnedLocation()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        Assert.IsFalse(manager.IsPinnedToDock(location));
+    }
+
+    [TestMethod]
+    public void IsPinnedToDock_ReturnsFalseAfterUnpin()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        manager.PinToDock(location);
+        manager.UnpinFromDock(location);
+
+        Assert.IsFalse(manager.IsPinnedToDock(location));
+    }
+
+    // ---------------------------------------------------------------
+    // GetDockPins()
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void GetDockPins_WithNoPins_ReturnsEmpty()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+
+        var pins = manager.GetDockPins();
+
+        Assert.IsNotNull(pins);
+        Assert.AreEqual(0, pins.Count);
+    }
+
+    [TestMethod]
+    public void GetDockPins_ReturnsAllPinnedLocations()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        manager.PinToDock(new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 });
+        manager.PinToDock(new GeocodingResult { Name = "Portland", Latitude = 45.5, Longitude = -122.7 });
+        manager.PinToDock(new GeocodingResult { Name = "Vancouver", Latitude = 49.3, Longitude = -123.1 });
+
+        Assert.AreEqual(3, manager.GetDockPins().Count);
+    }
+
+    // ---------------------------------------------------------------
+    // DockPinsChanged event
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void DockPinsChanged_FiresOnPin()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        var eventFired = false;
+        manager.DockPinsChanged += (_, _) => eventFired = true;
+
+        manager.PinToDock(location);
+
+        Assert.IsTrue(eventFired, "DockPinsChanged should fire when a location is pinned");
+    }
+
+    [TestMethod]
+    public void DockPinsChanged_FiresOnUnpin()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        manager.PinToDock(location);
+
+        var eventFired = false;
+        manager.DockPinsChanged += (_, _) => eventFired = true;
+
+        manager.UnpinFromDock(location);
+
+        Assert.IsTrue(eventFired, "DockPinsChanged should fire when a location is unpinned");
+    }
+
+    [TestMethod]
+    public void DockPinsChanged_DoesNotFireOnDuplicatePin()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+        manager.PinToDock(location);
+
+        var eventFired = false;
+        manager.DockPinsChanged += (_, _) => eventFired = true;
+
+        manager.PinToDock(location);
+
+        Assert.IsFalse(eventFired, "DockPinsChanged should NOT fire when pinning a duplicate location");
+    }
+
+    [TestMethod]
+    public void DockPinsChanged_DoesNotFireOnUnpinNonExistent()
+    {
+        var manager = new DockPinsManager(_tempFilePath);
+        var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+        var eventFired = false;
+        manager.DockPinsChanged += (_, _) => eventFired = true;
+
+        manager.UnpinFromDock(location);
+
+        Assert.IsFalse(eventFired, "DockPinsChanged should NOT fire when unpinning a location that isn't pinned");
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor / persistence
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void Constructor_WithMissingFile_StartsEmpty()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"weather-test-no-dock-{Guid.NewGuid()}.json");
+
+        var manager = new DockPinsManager(nonExistentPath);
+
+        Assert.AreEqual(0, manager.GetDockPins().Count);
+    }
+
+    [TestMethod]
+    public void Constructor_LoadsExistingDataFromFile()
+    {
+        var location = new GeocodingResult
+        {
+            Name = "Vancouver",
+            Latitude = 49.3,
+            Longitude = -123.1,
+            Admin1 = "British Columbia",
+            Country = "Canada",
+        };
+
+        var manager1 = new DockPinsManager(_tempFilePath);
+        manager1.PinToDock(location);
+
+        var manager2 = new DockPinsManager(_tempFilePath);
+
+        Assert.AreEqual(1, manager2.GetDockPins().Count);
+        Assert.AreEqual("Vancouver", manager2.GetDockPins()[0].Name);
+    }
+
+    [TestMethod]
+    public void DockPins_AreIndependentFromFavorites()
+    {
+        var favoritesPath = Path.Combine(Path.GetTempPath(), $"weather-test-fav-indep-{Guid.NewGuid()}.json");
+        try
+        {
+            var favorites = new FavoritesManager(favoritesPath);
+            var dockPins = new DockPinsManager(_tempFilePath);
+            var location = new GeocodingResult { Name = "Seattle", Latitude = 47.6, Longitude = -122.3 };
+
+            favorites.Favorite(location);
+
+            // Favoriting a location must not pin it to the dock.
+            Assert.IsFalse(dockPins.IsPinnedToDock(location));
+            Assert.AreEqual(0, dockPins.GetDockPins().Count);
+
+            dockPins.PinToDock(location);
+
+            // Pinning to the dock must not affect favorites membership either way.
+            Assert.IsTrue(favorites.IsFavorite(location));
+            Assert.IsTrue(dockPins.IsPinnedToDock(location));
+        }
+        finally
+        {
+            if (File.Exists(favoritesPath))
+            {
+                File.Delete(favoritesPath);
+            }
+        }
+    }
+}

--- a/WeatherExtension.Tests/RollingFileLoggerTests.cs
+++ b/WeatherExtension.Tests/RollingFileLoggerTests.cs
@@ -11,10 +11,12 @@ namespace Microsoft.CmdPal.Ext.Weather.UnitTests;
 /// <summary>
 /// Tests for <see cref="RollingFileLogger"/>.
 ///
-/// The singleton writes to <c>AppContext.BaseDirectory/Logs/</c>, which in
-/// the test runner resolves to the test output directory. Each test flushes
-/// the logger before and after to close the file handle, ensuring reads and
-/// cleanups are not blocked by an open <see cref="FileStream"/>.
+/// The singleton writes to a writable per-user location under
+/// <c>LocalApplicationData\Microsoft.CmdPal\WeatherLogs</c>. Tests read the
+/// active directory from <see cref="RollingFileLogger.LogDirectory"/> rather
+/// than assuming a path. Each test flushes the logger before and after to
+/// close the file handle, ensuring reads and cleanups are not blocked by an
+/// open <see cref="FileStream"/>.
 /// </summary>
 [TestClass]
 public class RollingFileLoggerTests

--- a/WeatherExtension.Tests/WeatherListPageTests.cs
+++ b/WeatherExtension.Tests/WeatherListPageTests.cs
@@ -22,6 +22,7 @@ public class WeatherListPageTests
 
 	private string _settingsPath = string.Empty;
 	private string _favoritesPath = string.Empty;
+	private string _dockPinsPath = string.Empty;
 	
 
 	[TestInitialize]
@@ -29,12 +30,13 @@ public class WeatherListPageTests
 	{
 		_settingsPath = Path.Combine(Path.GetTempPath(), $"weather-list-settings-{Guid.NewGuid()}.json");
 		_favoritesPath = Path.Combine(Path.GetTempPath(), $"weather-list-fav-{Guid.NewGuid()}.json");
+		_dockPinsPath = Path.Combine(Path.GetTempPath(), $"weather-list-dock-{Guid.NewGuid()}.json");
 	}
 
 	[TestCleanup]
 	public void Cleanup()
 	{
-		foreach (var path in new[] { _settingsPath, _favoritesPath })
+		foreach (var path in new[] { _settingsPath, _favoritesPath, _dockPinsPath })
 		{
 			if (File.Exists(path))
 			{
@@ -157,12 +159,14 @@ public class WeatherListPageTests
 
 	private WeatherListPage CreatePage(
 		FavoritesManager? favorites = null,
-		StubGeocodingService? geocoding = null)
+		StubGeocodingService? geocoding = null,
+		DockPinsManager? dockPins = null)
 	{
 		return new WeatherListPage(
 			new StubWeatherService(),
 			geocoding ?? new StubGeocodingService(),
 			new WeatherSettingsManager(_settingsPath),
-			favorites ?? new FavoritesManager(_favoritesPath));
+			favorites ?? new FavoritesManager(_favoritesPath),
+			dockPins ?? new DockPinsManager(_dockPinsPath));
 	}
 }

--- a/WeatherExtension/Commands/PinToDockCommand.cs
+++ b/WeatherExtension/Commands/PinToDockCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class PinToDockCommand : InvokableCommand
+{
+	private readonly GeocodingResult _location;
+	private readonly DockPinsManager _dockPinsManager;
+
+	public PinToDockCommand(GeocodingResult location, DockPinsManager dockPinsManager)
+	{
+		_location = location;
+		_dockPinsManager = dockPinsManager;
+		Name = Resources.pin_to_dock_command_name;
+		Icon = new IconInfo("\uE840"); // Pin icon
+	}
+
+	public override string Id => "com.baldbeardedbuilder.cmdpal.weather.pintodock";
+
+	public override ICommandResult Invoke()
+	{
+		_dockPinsManager.PinToDock(_location);
+		return CommandResult.KeepOpen();
+	}
+}

--- a/WeatherExtension/Commands/SaveLogsCommand.cs
+++ b/WeatherExtension/Commands/SaveLogsCommand.cs
@@ -24,7 +24,19 @@ internal sealed partial class SaveLogsCommand : InvokableCommand
             RollingFileLogger.Instance.Flush();
 
             var logDir = RollingFileLogger.Instance.LogDirectory;
+
+            // Make sure the directory exists even if nothing has been logged
+            // yet, so we always produce a zip for the user to attach.
+            Directory.CreateDirectory(logDir);
+
             var desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            if (string.IsNullOrEmpty(desktop))
+            {
+                // Desktop can be empty/redirected in some profiles — fall back
+                // to the user profile so the zip still lands somewhere findable.
+                desktop = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            }
+
             var zipName = $"WeatherExtension-Logs-{DateTime.Now:yyyy-MM-dd}.zip";
             var zipPath = Path.Combine(desktop, zipName);
 
@@ -34,23 +46,28 @@ internal sealed partial class SaveLogsCommand : InvokableCommand
                 File.Delete(zipPath);
             }
 
-            // Add only *.log files — skip any unrelated files that may be in the directory.
-            if (Directory.Exists(logDir))
+            // Always create the archive — add only *.log files, skipping any
+            // unrelated files that may be in the directory.
+            var fileCount = 0;
+            using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create))
             {
-                using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create);
                 foreach (var logFile in Directory.EnumerateFiles(logDir, "*.log"))
                 {
                     archive.CreateEntryFromFile(logFile, Path.GetFileName(logFile), CompressionLevel.Optimal);
+                    fileCount++;
                 }
             }
 
-            WeatherLogger.LogToHost(MessageState.Info, $"Logs saved to: {zipPath}");
+            WeatherLogger.LogToHost(MessageState.Info, $"Logs saved to: {zipPath} ({fileCount} file(s))");
+
+            // Surface a visible confirmation — previously this command gave no
+            // feedback, so users assumed nothing happened.
+            return CommandResult.ShowToast(Resources.bug_report_logs_saved);
         }
         catch (Exception ex)
         {
             WeatherLogger.LogToHost(MessageState.Error, $"SaveLogsCommand failed: {ex.Message}");
+            return CommandResult.ShowToast(Resources.bug_report_logs_save_failed);
         }
-
-        return CommandResult.KeepOpen();
     }
 }

--- a/WeatherExtension/Commands/UnpinFromDockCommand.cs
+++ b/WeatherExtension/Commands/UnpinFromDockCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BaldBeardedBuilder.WeatherExtension;
+using Microsoft.CmdPal.Ext.Weather.Models;
+using Microsoft.CmdPal.Ext.Weather.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Weather.Commands;
+
+internal sealed partial class UnpinFromDockCommand : InvokableCommand
+{
+	private readonly GeocodingResult _location;
+	private readonly DockPinsManager _dockPinsManager;
+
+	public UnpinFromDockCommand(GeocodingResult location, DockPinsManager dockPinsManager)
+	{
+		_location = location;
+		_dockPinsManager = dockPinsManager;
+		Name = Resources.unpin_from_dock_command_name;
+		Icon = new IconInfo("\uE77A"); // Unpin icon
+	}
+
+	public override string Id => "com.baldbeardedbuilder.cmdpal.weather.unpinfromdock";
+
+	public override ICommandResult Invoke()
+	{
+		_dockPinsManager.UnpinFromDock(_location);
+		return CommandResult.KeepOpen();
+	}
+}

--- a/WeatherExtension/Pages/WeatherListPage.cs
+++ b/WeatherExtension/Pages/WeatherListPage.cs
@@ -20,6 +20,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	private readonly IGeocodingService _geocodingService;
 	private readonly WeatherSettingsManager _settingsManager;
 	private readonly FavoritesManager _favoritesManager;
+	private readonly DockPinsManager _dockPinsManager;
 	private readonly Lock _sync = new();
 	private readonly CancellationTokenSource _cts = new();
 
@@ -34,17 +35,20 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		IWeatherService weatherService,
 		IGeocodingService geocodingService,
 		WeatherSettingsManager settingsManager,
-		FavoritesManager favoritesManager)
+		FavoritesManager favoritesManager,
+		DockPinsManager dockPinsManager)
 	{
 		ArgumentNullException.ThrowIfNull(weatherService);
 		ArgumentNullException.ThrowIfNull(geocodingService);
 		ArgumentNullException.ThrowIfNull(settingsManager);
 		ArgumentNullException.ThrowIfNull(favoritesManager);
+		ArgumentNullException.ThrowIfNull(dockPinsManager);
 
 		_weatherService = weatherService;
 		_geocodingService = geocodingService;
 		_settingsManager = settingsManager;
 		_favoritesManager = favoritesManager;
+		_dockPinsManager = dockPinsManager;
 
 		Name = Resources.plugin_name;
 		Title = Resources.plugin_name;
@@ -57,6 +61,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 
 		_settingsManager.Settings.SettingsChanged += OnSettingsChanged;
 		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
+		_dockPinsManager.DockPinsChanged += OnDockPinsChanged;
 	}
 
 	private async void LoadFavoriteLocations(CancellationToken searchCt = default)
@@ -284,10 +289,32 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 			});
 		}
 
+		// Dock pinning is independent of favorites — a location can be pinned to
+		// the Dock without being a favorite. Offer the matching toggle command.
+		if (_dockPinsManager.IsPinnedToDock(location))
+		{
+			moreCommands.Add(new CommandContextItem(new UnpinFromDockCommand(location, _dockPinsManager))
+			{
+				RequestedShortcut = new KeyChord(VirtualKeyModifiers.Control, (int)VirtualKey.P, 0),
+			});
+		}
+		else
+		{
+			moreCommands.Add(new CommandContextItem(new PinToDockCommand(location, _dockPinsManager))
+			{
+				RequestedShortcut = new KeyChord(VirtualKeyModifiers.Control, (int)VirtualKey.P, 0),
+			});
+		}
+
 		var tags = new List<ITag>();
 		if (_favoritesManager.IsFavorite(location))
 		{
 			tags.Add(new Tag(Resources.favorite_tag) { Icon = new IconInfo("\u2B50") });
+		}
+
+		if (_dockPinsManager.IsPinnedToDock(location))
+		{
+			tags.Add(new Tag(Resources.dock_pinned_tag) { Icon = new IconInfo("\uE840") });
 		}
 
 		var item = new ListItem(detailPage)
@@ -540,6 +567,21 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 		}
 	}
 
+	private void OnDockPinsChanged(object? sender, EventArgs e)
+	{
+		// A dock pin/unpin changes which toggle command and tag a row shows,
+		// so re-render the current view just like a favorites change does.
+		if (string.IsNullOrWhiteSpace(_lastSearchQuery))
+		{
+			var ct = ResetSearchToken();
+			LoadFavoriteLocations(ct);
+		}
+		else
+		{
+			RefreshWeather();
+		}
+	}
+
 	public void RefreshWeather()
 	{
 		var ct = ResetSearchToken();
@@ -602,6 +644,7 @@ internal sealed partial class WeatherListPage : DynamicListPage, IDisposable
 	{
 		_settingsManager.Settings.SettingsChanged -= OnSettingsChanged;
 		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
+		_dockPinsManager.DockPinsChanged -= OnDockPinsChanged;
 		_searchCts?.Cancel();
 		_searchCts?.Dispose();
 		_cts?.Cancel();

--- a/WeatherExtension/Properties/Resources.Designer.cs
+++ b/WeatherExtension/Properties/Resources.Designer.cs
@@ -646,6 +646,10 @@ namespace Microsoft.CmdPal.Ext.Weather {
         public static string bug_report_open_github { get { return ResourceManager.GetString("bug_report_open_github", resourceCulture); } }
         public static string bug_report_instructions { get { return ResourceManager.GetString("bug_report_instructions", resourceCulture); } }
         public static string bug_report_logs_saved { get { return ResourceManager.GetString("bug_report_logs_saved", resourceCulture); } }
+        public static string bug_report_logs_save_failed { get { return ResourceManager.GetString("bug_report_logs_save_failed", resourceCulture); } }
+        public static string pin_to_dock_command_name { get { return ResourceManager.GetString("pin_to_dock_command_name", resourceCulture); } }
+        public static string unpin_from_dock_command_name { get { return ResourceManager.GetString("unpin_from_dock_command_name", resourceCulture); } }
+        public static string dock_pinned_tag { get { return ResourceManager.GetString("dock_pinned_tag", resourceCulture); } }
 
     }
 }

--- a/WeatherExtension/Properties/Resources.ar.resx
+++ b/WeatherExtension/Properties/Resources.ar.resx
@@ -132,4 +132,8 @@
 
 سيتم حفظ ملف ZIP على سطح المكتب.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>تم حفظ السجلات على سطح المكتب</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>تعذّر حفظ السجلات على سطح المكتب</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>تثبيت في الإرساء</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>إلغاء التثبيت من الإرساء</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>مثبّت</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.de.resx
+++ b/WeatherExtension/Properties/Resources.de.resx
@@ -132,4 +132,8 @@ Wien, Österreich</value></data><data name="search_hint_favorite_shortcut" xml:s
 
 Die ZIP-Datei wird auf Ihrem Desktop gespeichert.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Protokolle auf Desktop gespeichert</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Protokolle konnten nicht auf dem Desktop gespeichert werden</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>An Dock anheften</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Vom Dock lösen</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Angeheftet</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.es.resx
+++ b/WeatherExtension/Properties/Resources.es.resx
@@ -132,4 +132,8 @@ Buenos Aires, Argentina</value></data><data name="search_hint_favorite_shortcut"
 
 El archivo ZIP se guardará en tu escritorio.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Registros guardados en el escritorio</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>No se pudieron guardar los registros en el escritorio</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Anclar al Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Desanclar del Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Anclado</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.fr.resx
+++ b/WeatherExtension/Properties/Resources.fr.resx
@@ -132,4 +132,8 @@ Bruxelles, Belgique</value></data><data name="search_hint_favorite_shortcut" xml
 
 Le fichier ZIP sera enregistré sur votre bureau.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Journaux enregistrés sur le bureau</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Impossible d'enregistrer les journaux sur le bureau</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Épingler au Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Détacher du Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Épinglé</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.it.resx
+++ b/WeatherExtension/Properties/Resources.it.resx
@@ -132,4 +132,8 @@ Lugano, Svizzera</value></data><data name="search_hint_favorite_shortcut" xml:sp
 
 Il file ZIP verrà salvato sul Desktop.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Log salvati sul Desktop</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Impossibile salvare i log sul Desktop</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Aggiungi al Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Rimuovi dal Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Nel Dock</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.ja.resx
+++ b/WeatherExtension/Properties/Resources.ja.resx
@@ -132,4 +132,8 @@
 
 ZIP ファイルはデスクトップに保存されます。</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>ログをデスクトップに保存しました</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>ログをデスクトップに保存できませんでした</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>ドックにピン留め</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>ドックからピン留めを外す</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>ドック</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.ko.resx
+++ b/WeatherExtension/Properties/Resources.ko.resx
@@ -132,4 +132,8 @@
 
 ZIP 파일이 바탕화면에 저장됩니다.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>로그가 바탕화면에 저장됨</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>로그를 바탕화면에 저장할 수 없습니다</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>독에 고정</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>독에서 고정 해제</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>고정됨</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.nl.resx
+++ b/WeatherExtension/Properties/Resources.nl.resx
@@ -132,4 +132,8 @@ Brussel, België</value></data><data name="search_hint_favorite_shortcut" xml:sp
 
 Het ZIP-bestand wordt op uw bureaublad opgeslagen.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Logbestanden opgeslagen op bureaublad</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Kan logbestanden niet op bureaublad opslaan</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Vastmaken aan Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Losmaken van Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Vastgemaakt</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.pl.resx
+++ b/WeatherExtension/Properties/Resources.pl.resx
@@ -132,4 +132,8 @@ Berlin, Niemcy</value></data><data name="search_hint_favorite_shortcut" xml:spac
 
 Plik ZIP zostanie zapisany na pulpicie.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Logi zapisano na pulpicie</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Nie można zapisać logów na pulpicie</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Przypnij do Docka</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Odepnij od Docka</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Przypięte</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.pt-BR.resx
+++ b/WeatherExtension/Properties/Resources.pt-BR.resx
@@ -132,4 +132,8 @@ Lisboa, Portugal</value></data><data name="search_hint_favorite_shortcut" xml:sp
 
 O arquivo ZIP será salvo na sua área de trabalho.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Logs salvos na área de trabalho</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Não foi possível salvar os logs na área de trabalho</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Fixar no Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Desafixar do Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Fixado</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.resx
+++ b/WeatherExtension/Properties/Resources.resx
@@ -396,4 +396,8 @@ Berlin, Germany</value></data><data name="search_hint_favorite_shortcut" xml:spa
 
 The zip file will be saved to your Desktop.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Logs saved to Desktop</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Could not save logs to Desktop</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Pin to Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Unpin from Dock</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Docked</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.ru.resx
+++ b/WeatherExtension/Properties/Resources.ru.resx
@@ -132,4 +132,8 @@
 
 ZIP-файл будет сохранён на рабочем столе.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Журналы сохранены на рабочий стол</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Не удалось сохранить журналы на рабочий стол</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Закрепить на панели</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Открепить от панели</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Закреплено</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.tr.resx
+++ b/WeatherExtension/Properties/Resources.tr.resx
@@ -257,4 +257,8 @@ Berlin, Almanya</value></data><data name="search_hint_favorite_shortcut" xml:spa
 
 ZIP dosyası masaüstünüze kaydedilecektir.</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>Günlükler masaüstüne kaydedildi</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>Günlükler masaüstüne kaydedilemedi</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>Dock'a Sabitle</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>Dock'tan Kaldır</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>Sabit</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.zh-Hans.resx
+++ b/WeatherExtension/Properties/Resources.zh-Hans.resx
@@ -132,4 +132,8 @@
 
 ZIP 文件将保存到您的桌面。</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>日志已保存到桌面</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>无法将日志保存到桌面</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>固定到 Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>从 Dock 取消固定</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>已固定</value></data>
 </root>

--- a/WeatherExtension/Properties/Resources.zh-Hant.resx
+++ b/WeatherExtension/Properties/Resources.zh-Hant.resx
@@ -132,4 +132,8 @@
 
 ZIP 檔案將儲存到您的桌面。</value></data>
   <data name="bug_report_logs_saved" xml:space="preserve"><value>日誌已儲存到桌面</value></data>
+  <data name="bug_report_logs_save_failed" xml:space="preserve"><value>無法將日誌儲存到桌面</value></data>
+  <data name="pin_to_dock_command_name" xml:space="preserve"><value>釘選到 Dock</value></data>
+  <data name="unpin_from_dock_command_name" xml:space="preserve"><value>從 Dock 取消釘選</value></data>
+  <data name="dock_pinned_tag" xml:space="preserve"><value>已釘選</value></data>
 </root>

--- a/WeatherExtension/Services/DockPinsManager.cs
+++ b/WeatherExtension/Services/DockPinsManager.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Bald Bearded Builder LLC
+// Bald Bearded Builder LLC licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Weather.Models;
+
+namespace Microsoft.CmdPal.Ext.Weather.Services;
+
+/// <summary>
+/// Stores the locations the user has explicitly pinned to the Command Palette
+/// Dock. This is a separate concept from Favorites: a location can be favorited
+/// without being docked and vice versa. Dock bands are driven exclusively by
+/// this store.
+/// </summary>
+public sealed class DockPinsManager
+{
+	private readonly JsonFileStore<PinnedLocation> _store;
+
+	public event EventHandler? DockPinsChanged;
+
+	public DockPinsManager()
+	{
+		var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		var directory = Path.Combine(localAppData, "Microsoft.CmdPal");
+		Directory.CreateDirectory(directory);
+		var filePath = Path.Combine(directory, "dock-pinned-weather-locations.json");
+		_store = new JsonFileStore<PinnedLocation>(filePath, WeatherJsonContext.Default.ListPinnedLocation, "dock-pinned locations");
+	}
+
+	internal DockPinsManager(string filePath)
+	{
+		_store = new JsonFileStore<PinnedLocation>(filePath, WeatherJsonContext.Default.ListPinnedLocation, "dock-pinned locations");
+	}
+
+	public void PinToDock(GeocodingResult location)
+	{
+		var added = _store.Add(
+			new PinnedLocation
+			{
+				Latitude = location.Latitude,
+				Longitude = location.Longitude,
+				DisplayName = location.DisplayName,
+				Name = location.Name,
+				Admin1 = location.Admin1,
+				Country = location.Country,
+			},
+			p => Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+				 Math.Abs(p.Longitude - location.Longitude) < 0.01);
+
+		if (added)
+		{
+			DockPinsChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	public void UnpinFromDock(GeocodingResult location)
+	{
+		var removed = _store.Remove(
+			p => Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+				 Math.Abs(p.Longitude - location.Longitude) < 0.01);
+
+		if (removed)
+		{
+			DockPinsChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	public bool IsPinnedToDock(GeocodingResult location)
+	{
+		return _store.Any(
+			p => Math.Abs(p.Latitude - location.Latitude) < 0.01 &&
+				 Math.Abs(p.Longitude - location.Longitude) < 0.01);
+	}
+
+	public List<PinnedLocation> GetDockPins()
+	{
+		return _store.GetAll();
+	}
+}

--- a/WeatherExtension/Services/RollingFileLogger.cs
+++ b/WeatherExtension/Services/RollingFileLogger.cs
@@ -39,7 +39,14 @@ internal sealed partial class RollingFileLogger : IDisposable
 
 	private RollingFileLogger()
 	{
-		_logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+		// Use LocalApplicationData rather than AppContext.BaseDirectory. For a
+		// packaged (MSIX/Store) install the base directory lives under
+		// C:\Program Files\WindowsApps\... which is read-only for standard
+		// users, so Directory.CreateDirectory would throw and logging would
+		// silently never write. FavoritesManager and WeatherSettingsManager
+		// already store their data here for the same reason.
+		var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		_logDirectory = Path.Combine(localAppData, "Microsoft.CmdPal", "WeatherLogs");
 	}
 
 	public void Log(LogLevel level, string message)

--- a/WeatherExtension/WeatherCommandsProvider.cs
+++ b/WeatherExtension/WeatherCommandsProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using BaldBeardedBuilder.WeatherExtension;
 using Microsoft.CmdPal.Ext.Weather.DockBands;
 using Microsoft.CmdPal.Ext.Weather.Pages;
 using Microsoft.CmdPal.Ext.Weather.Services;
@@ -17,6 +18,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	private readonly OpenMeteoService _weatherService = new();
 	private readonly GeocodingService _geocodingService = new();
 	private readonly FavoritesManager _favoritesManager = new();
+	private readonly DockPinsManager _dockPinsManager = new();
 	private readonly WeatherListPage _weatherPage;
 	private readonly WeatherSettingsPage _settingsPage;
 	private readonly SubmitBugPage _submitBugPage = new();
@@ -24,12 +26,12 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 	private readonly Lock _bandsSync = new();
 
 	// Cache band instances by their lat/lon key. The host calls
-	// GetDockBands() not just on FavoritesChanged but also when the user
+	// GetDockBands() not just on DockPinsChanged but also when the user
 	// hovers a band, opens dock customization, etc. Re-creating bands on
 	// every call meant each hover bounced the band's Title back to
 	// "Loading weather…" while UpdateWeatherAsync re-ran from scratch and
 	// re-issued network calls. By keeping a stable band per location and
-	// only adding/disposing entries on actual favorite changes, the
+	// only adding/disposing entries on actual dock-pin changes, the
 	// resolved title persists across re-queries and the user only sees
 	// the loading state on the very first appearance.
 	private readonly Dictionary<string, BandEntry> _bandsByKey = new(StringComparer.Ordinal);
@@ -42,11 +44,18 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		DisplayName = Resources.plugin_name;
 		Icon = Icons.WeatherIcon;
 
-		// Favorites are the single source of truth for dock bands. When the
-		// user toggles a favorite — from the search list, the band card, or
-		// the right-click context menu — the dock should reflect that change
-		// immediately, so we re-emit ItemsChanged on every update.
-		_favoritesManager.FavoritesChanged += OnFavoritesChanged;
+		// One-time migration: earlier versions drove dock bands from Favorites.
+		// Seed the new independent dock-pin store from existing favorites so
+		// users who relied on that behavior don't lose their dock content when
+		// the source switches. Runs only when the dock-pin store is still empty
+		// and the user actually has favorites.
+		MigrateFavoritesToDockPinsIfNeeded();
+
+		// Dock pins are the single source of truth for dock bands. When the
+		// user pins/unpins a location — from the search list or the right-click
+		// context menu — the dock should reflect that change immediately, so we
+		// re-emit ItemsChanged on every update.
+		_dockPinsManager.DockPinsChanged += OnDockPinsChanged;
 
 		Settings = _settingsManager.Settings;
 
@@ -56,7 +65,7 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		_settingsPage = new WeatherSettingsPage(_settingsManager);
 
 		// Create main weather page
-		_weatherPage = new WeatherListPage(_weatherService, _geocodingService, _settingsManager, _favoritesManager);
+		_weatherPage = new WeatherListPage(_weatherService, _geocodingService, _settingsManager, _favoritesManager, _dockPinsManager);
 
 		_topLevelItems =
 		[
@@ -69,28 +78,50 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		];
 	}
 
+	private void MigrateFavoritesToDockPinsIfNeeded()
+	{
+		try
+		{
+			if (_dockPinsManager.GetDockPins().Count > 0)
+			{
+				return;
+			}
+
+			foreach (var favorite in _favoritesManager.GetFavorites())
+			{
+				_dockPinsManager.PinToDock(favorite.ToGeocodingResult());
+			}
+		}
+		catch (Exception ex)
+		{
+			WeatherLogger.LogToHost(
+				MessageState.Error,
+				$"Dock pin migration failed: {ex.Message}");
+		}
+	}
+
 	public override ICommandItem[] TopLevelCommands() => _topLevelItems;
 
 	public override ICommandItem[] GetDockBands()
 	{
-		var favorites = _favoritesManager.GetFavorites();
-		var dockItems = new List<ICommandItem>(favorites.Count);
+		var dockPins = _dockPinsManager.GetDockPins();
+		var dockItems = new List<ICommandItem>(dockPins.Count);
 
 		List<PinnedWeatherBand> bandsToDispose = [];
 
 		lock (_bandsSync)
 		{
 			// Reconcile against the cache so a hover or any other
-			// non-favorite-changing GetDockBands() call returns the same
+			// non-pin-changing GetDockBands() call returns the same
 			// band instances with their already-resolved weather data
 			// instead of fresh "Loading weather…" placeholders.
 			var fresh = new Dictionary<string, BandEntry>(StringComparer.Ordinal);
-			foreach (var favorite in favorites)
+			foreach (var pin in dockPins)
 			{
-				var key = BandKey(favorite.Latitude, favorite.Longitude);
+				var key = BandKey(pin.Latitude, pin.Longitude);
 				if (fresh.ContainsKey(key))
 				{
-					// User favorited two locations that round-trip to the
+					// User pinned two locations that round-trip to the
 					// same lat/lon at our F4 precision — keep the first.
 					continue;
 				}
@@ -102,13 +133,13 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 				}
 				else
 				{
-					var entry = CreateBand(favorite.ToGeocodingResult());
+					var entry = CreateBand(pin.ToGeocodingResult());
 					fresh[key] = entry;
 					dockItems.Add(entry.DockItem);
 				}
 			}
 
-			// Dispose bands whose location is no longer favorited.
+			// Dispose bands whose location is no longer pinned to the dock.
 			foreach (var (key, entry) in _bandsByKey)
 			{
 				if (!fresh.ContainsKey(key))
@@ -152,22 +183,22 @@ public sealed partial class WeatherCommandsProvider : CommandProvider
 		return new BandEntry(pinnedBand, dockItem);
 	}
 
-	private void OnFavoritesChanged(object? sender, EventArgs e)
+	private void OnDockPinsChanged(object? sender, EventArgs e)
 	{
 		// Reconcile immediately — don't wait for the host to call GetDockBands().
-		// If the user re-favorites a location before the host polls, a stale
+		// If the user re-pins a location before the host polls, a stale
 		// disposed band would otherwise be reused from the cache.
 		_ = GetDockBands();
 
 		// Tell the host to re-query GetDockBands() so the band list reflects
-		// the user's latest favorite/unfavorite action without forcing a
+		// the user's latest pin/unpin action without forcing a
 		// full extension reload.
 		RaiseItemsChanged(0);
 	}
 
 	public override void Dispose()
 	{
-		_favoritesManager.FavoritesChanged -= OnFavoritesChanged;
+		_dockPinsManager.DockPinsChanged -= OnDockPinsChanged;
 		List<PinnedWeatherBand> bandsToDispose;
 		lock (_bandsSync)
 		{


### PR DESCRIPTION
Resolves the two problems reported in #142.

## Problem 1: No "Pin to Dock" option on a location

Dock bands were driven by the Favorites list, and there was no dedicated pin action on a location. The "Pin to Dock" the reporter saw was Command Palette's generic pin of the top-level launcher, not a per-city pin.

**Fix:** Dock pinning is now its own feature, decoupled from Favorites:
- New `DockPinsManager` store (own JSON file under `LocalApplicationData\Microsoft.CmdPal`), mirroring `FavoritesManager`.
- New `PinToDockCommand` / `UnpinFromDockCommand` on every location, plus a "Docked" tag.
- `GetDockBands()` now reads from the dock-pin store instead of favorites.
- A one-time migration seeds dock pins from existing favorites so current users keep their dock content.
- New resource strings added across all 15 locales.

## Problem 2: "Save Logs to Desktop" silently did nothing

On Store/MSIX installs the logger wrote to a read-only program folder, so `Directory.CreateDirectory` threw (swallowed), no logs were ever created, and the zip step was skipped.

**Fix:**
- `RollingFileLogger` writes to a writable `LocalApplicationData\Microsoft.CmdPal\WeatherLogs` path.
- `SaveLogsCommand` always creates a zip (with a Desktop -> UserProfile fallback) and shows a confirmation toast.

## Testing

- Build succeeds.
- Full test suite passes (317/317), including new `DockPinsManagerTests`.
- Updated existing test callers for the new `WeatherListPage` constructor and refreshed the README.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>